### PR TITLE
Automatically generate a gallery on RTD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.ipynb_checkpoints
-.DS_Store
 .ipynb_checkpoints/
+.DS_Store
 dask-worker-space/
+
+docs/_build/
+docs/documented_examples/
+docs/tutorials/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+# don't build PDF and ePub
+formats: []
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/DocumentedExamples/README.rst
+++ b/DocumentedExamples/README.rst
@@ -1,0 +1,4 @@
+Documented Examples
+===================
+
+These are some examples of what you can do with the COSIMA Cookbook

--- a/Tutorials/README.rst
+++ b/Tutorials/README.rst
@@ -1,0 +1,4 @@
+COSIMA Recipes Tutorials
+========================
+
+These are designed to get you up and running with the COSIMA Cookbook!

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,64 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'COSIMA Recipes'
+copyright = '2020, COSIMA'
+author = 'COSIMA'
+
+
+# -- General configuration ---------------------------------------------------
+
+master_doc = 'index'
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx_nbexamples',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'default'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# -- Example Gallery ---------------------------------------------------------
+example_gallery_config = {
+    'examples_dirs': ['../Tutorials', '../DocumentedExamples'],
+    'gallery_dirs': ['tutorials', 'documented_examples'],
+    'pattern': r'.+\.ipynb',
+    'dont_preprocess': True,
+    'toctree_depth': 0,
+}

--- a/docs/guidelines.rst
+++ b/docs/guidelines.rst
@@ -1,0 +1,13 @@
+Notebook Guidelines
+===================
+
+For optimum presentation in the gallery, notebooks should follow a few
+simple rules:
+
+1. The first cell must be a Markdown cell containing a title
+2. The first cell should include a short summary, which will be shown
+   as a tooltip
+
+By default, the chosen thumbnail is the last matplotlib figure in the
+notebook. This can be changed by setting the ``thumbnail_figures`` key
+in the notebook metadata to the integer index of the desired figure.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,22 @@
+.. COSIMA Recipes documentation master file, created by
+   sphinx-quickstart on Mon Apr  6 11:03:01 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to COSIMA Recipes's documentation!
+==========================================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents:
+
+   tutorials/index
+   documented_examples/index
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to COSIMA Recipes's documentation!
 
    tutorials/index
    documented_examples/index
+   guidelines
 
 
 Indices and tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-nbexamples


### PR DESCRIPTION
I've set up a readthedocs page for this repository at https://cosima-recipes.readthedocs.io/en/latest/. Note that until this PR is merged, it won't be very interesting! You can view the docs corresponding to this PR's branch at https://cosima-recipes.readthedocs.io/en/gallery/

This is an automatically-generated gallery using the [sphinx-nbexamples](https://sphinx-nbexamples.readthedocs.io/en/latest/index.html) extension, which renders the tutorial notebooks and documented examples, as well as providing a gallery page with a thumbnail image and summary. There are a few things to note:
* all the notebooks will need to be evaluated to have an image that will show up in the gallery
* the notebooks need to start with a markdown cell containing a title and a summary (I think most do already)
* we can control the thumbnail image by editing the notebook metadata, if desired

To unify with the COSIMA Cookbook itself, we will be able to include just the gallery pages on the API docs (see https://sphinx-nbexamples.readthedocs.io/en/latest/linkgalleries.html)

Closes #65 