### PR TITLE
Explain dask in regridding example

### DIFF
--- a/DocumentedExamples/Regridding.ipynb
+++ b/DocumentedExamples/Regridding.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +464,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-f90b1da8-1b8f-4ce3-9345-ef8367705d75' class='xr-array-in' type='checkbox' checked><label for='section-f90b1da8-1b8f-4ce3-9345-ef8367705d75' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c6340a68-f7a1-4e2d-91b3-5a9e9c6dac9f' class='xr-array-in' type='checkbox' checked><label for='section-c6340a68-f7a1-4e2d-91b3-5a9e9c6dac9f' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -558,8 +558,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-5022b4cc-b0fa-4147-9005-a5665f5ad6b0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5022b4cc-b0fa-4147-9005-a5665f5ad6b0' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-f036dbd9-af71-46a8-b216-dcecae7f3209' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f036dbd9-af71-46a8-b216-dcecae7f3209' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ba4693b0-1061-41d3-81c1-2bc459d01c54' class='xr-var-data-in' type='checkbox'><label for='data-ba4693b0-1061-41d3-81c1-2bc459d01c54' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-f34b9120-076e-480d-870d-5f091943d4a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f34b9120-076e-480d-870d-5f091943d4a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d22d7913-5066-499f-84f7-8677540443d5' class='xr-var-data-in' type='checkbox'><label for='data-d22d7913-5066-499f-84f7-8677540443d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
-       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-f11bff45-ab41-41ec-ac45-6298749a79f4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f11bff45-ab41-41ec-ac45-6298749a79f4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33389e47-2ff8-42f1-8971-dd2be01414dd' class='xr-var-data-in' type='checkbox'><label for='data-33389e47-2ff8-42f1-8971-dd2be01414dd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-49561b8a-377b-402e-bd26-d48b862094aa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-49561b8a-377b-402e-bd26-d48b862094aa' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-0ee09a01-1844-4371-aa45-a4e50b23eb22' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0ee09a01-1844-4371-aa45-a4e50b23eb22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c4d6db7-6b4a-4cc7-8363-da748d4390a9' class='xr-var-data-in' type='checkbox'><label for='data-0c4d6db7-6b4a-4cc7-8363-da748d4390a9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-b1e8e76d-ea5e-4161-98ff-4870d35b1386' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b1e8e76d-ea5e-4161-98ff-4870d35b1386' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b23cca59-cdca-434f-acf6-7bde48188aab' class='xr-var-data-in' type='checkbox'><label for='data-b23cca59-cdca-434f-acf6-7bde48188aab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
+       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-06832339-ec6e-4bea-8f03-a04d14216273' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06832339-ec6e-4bea-8f03-a04d14216273' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6b1f214e-e428-4620-b8b4-bc42598bf6d2' class='xr-var-data-in' type='checkbox'><label for='data-6b1f214e-e428-4620-b8b4-bc42598bf6d2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -582,7 +582,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-340b7a06-c071-4059-9b6f-b866febea842' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-340b7a06-c071-4059-9b6f-b866febea842' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0b95980-8621-4acd-aeb2-7aaa1fed888e' class='xr-var-data-in' type='checkbox'><label for='data-e0b95980-8621-4acd-aeb2-7aaa1fed888e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d06f840a-9c2c-47d2-9656-00fd473fd209' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d06f840a-9c2c-47d2-9656-00fd473fd209' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3e3eb4b8-87c2-49fa-91c9-3795678ca5ad' class='xr-var-data-in' type='checkbox'><label for='data-3e3eb4b8-87c2-49fa-91c9-3795678ca5ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0e6b2c15-3528-4ed0-840c-0f280de1dfd0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0e6b2c15-3528-4ed0-840c-0f280de1dfd0' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ced2b44f-525d-4faa-a90e-4f1737866a02' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ced2b44f-525d-4faa-a90e-4f1737866a02' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8f2320b-b748-4e97-8a5f-310991eb4b9d' class='xr-var-data-in' type='checkbox'><label for='data-f8f2320b-b748-4e97-8a5f-310991eb4b9d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-953cb2c7-e688-42a7-aa2d-eb4c5da6badf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-953cb2c7-e688-42a7-aa2d-eb4c5da6badf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ebd8b5c2-817e-471b-b764-0dcda087d716' class='xr-var-data-in' type='checkbox'><label for='data-ebd8b5c2-817e-471b-b764-0dcda087d716' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0f23811a-645c-43e1-97e3-4d1b6786373a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0f23811a-645c-43e1-97e3-4d1b6786373a' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 300, x: 360)>\n",
@@ -603,7 +603,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -992,7 +992,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-6a4ec635-1edf-44d4-905e-f9e7631920bb' class='xr-array-in' type='checkbox' checked><label for='section-6a4ec635-1edf-44d4-905e-f9e7631920bb' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-abecaa5f-be2b-40cc-a85d-100719e8cf57' class='xr-array-in' type='checkbox' checked><label for='section-abecaa5f-be2b-40cc-a85d-100719e8cf57' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1090,8 +1090,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-bd3ad6bd-6288-4acd-a674-e8e55a11044f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bd3ad6bd-6288-4acd-a674-e8e55a11044f' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-eff94347-a0d5-4970-b538-049acd4561b5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eff94347-a0d5-4970-b538-049acd4561b5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-17315ae2-0da9-4397-b869-8ff8884dfbea' class='xr-var-data-in' type='checkbox'><label for='data-17315ae2-0da9-4397-b869-8ff8884dfbea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-638a7d20-d8ed-4e4e-949c-f8bb54194aa3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-638a7d20-d8ed-4e4e-949c-f8bb54194aa3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fbaa8891-34ad-40e4-92c5-d255a717380c' class='xr-var-data-in' type='checkbox'><label for='data-fbaa8891-34ad-40e4-92c5-d255a717380c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
-       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-11759271-aea7-416f-ae52-4edde637ede6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11759271-aea7-416f-ae52-4edde637ede6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d21a3e44-3417-44ff-98ae-88fe16e3a420' class='xr-var-data-in' type='checkbox'><label for='data-d21a3e44-3417-44ff-98ae-88fe16e3a420' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-4fdce6a2-5035-473d-b1b9-481e47fe9434' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4fdce6a2-5035-473d-b1b9-481e47fe9434' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-3f9add76-964f-4d8a-a2ac-9b8ee4244459' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3f9add76-964f-4d8a-a2ac-9b8ee4244459' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bdf0ba54-4656-4779-916a-ad6bde4ca747' class='xr-var-data-in' type='checkbox'><label for='data-bdf0ba54-4656-4779-916a-ad6bde4ca747' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-ce5fc952-6c9d-4f50-b87e-2bbc88039c72' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ce5fc952-6c9d-4f50-b87e-2bbc88039c72' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d1d41d5-5059-4433-a801-3fada09904c6' class='xr-var-data-in' type='checkbox'><label for='data-6d1d41d5-5059-4433-a801-3fada09904c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
+       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-f55c8fe8-9ac0-457f-b6cc-641e88816185' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f55c8fe8-9ac0-457f-b6cc-641e88816185' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f59f07f-c9dc-4868-9d63-a909519bb521' class='xr-var-data-in' type='checkbox'><label for='data-2f59f07f-c9dc-4868-9d63-a909519bb521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 13, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 14, 0, 0, 0, 0),\n",
@@ -1114,7 +1114,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 14, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 14, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-bd3355b6-5ae7-4fd2-8e0d-9df585c0cae4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bd3355b6-5ae7-4fd2-8e0d-9df585c0cae4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d175f728-c50e-472e-8369-e409c9e6c173' class='xr-var-data-in' type='checkbox'><label for='data-d175f728-c50e-472e-8369-e409c9e6c173' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4e0b58fc-7b3f-4949-b920-cc1c1ce0956f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4e0b58fc-7b3f-4949-b920-cc1c1ce0956f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e8ed91a-4658-4af0-868d-1793158d9fa1' class='xr-var-data-in' type='checkbox'><label for='data-0e8ed91a-4658-4af0-868d-1793158d9fa1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2c05b4aa-b10b-4f5d-a102-707dfb446381' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2c05b4aa-b10b-4f5d-a102-707dfb446381' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-711d18e4-67bb-4f0b-9442-c27728db4cf7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-711d18e4-67bb-4f0b-9442-c27728db4cf7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-904ffb6d-59b5-4993-81ff-445c49d5a699' class='xr-var-data-in' type='checkbox'><label for='data-904ffb6d-59b5-4993-81ff-445c49d5a699' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a1955f57-f59a-488b-aed0-67d249eafc37' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a1955f57-f59a-488b-aed0-67d249eafc37' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0664a50d-8eca-48c1-a1f8-8d0362bb30bb' class='xr-var-data-in' type='checkbox'><label for='data-0664a50d-8eca-48c1-a1f8-8d0362bb30bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cf9d8bb3-f7b1-4bf7-98ef-a944941987cc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cf9d8bb3-f7b1-4bf7-98ef-a944941987cc' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 1080, x: 1440)>\n",
@@ -1135,7 +1135,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1152,7 +1152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -1524,7 +1524,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-9d1781a8-1d1a-4a52-8dac-0bd4ea4ffd22' class='xr-array-in' type='checkbox' checked><label for='section-9d1781a8-1d1a-4a52-8dac-0bd4ea4ffd22' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c03222dc-3caf-4b0a-b87a-ddbeb150effd' class='xr-array-in' type='checkbox' checked><label for='section-c03222dc-3caf-4b0a-b87a-ddbeb150effd' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1634,8 +1634,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-a115a9d8-7cdd-4bec-b3b3-e62c01b6e35f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a115a9d8-7cdd-4bec-b3b3-e62c01b6e35f' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-f70efd68-f37f-4b1a-b4ec-c265f6ccca3b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f70efd68-f37f-4b1a-b4ec-c265f6ccca3b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-10cabbc2-9779-4f63-9d25-8bc9405b5c6d' class='xr-var-data-in' type='checkbox'><label for='data-10cabbc2-9779-4f63-9d25-8bc9405b5c6d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-e424ac6a-571a-4567-a2eb-afa0b7a54e5b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e424ac6a-571a-4567-a2eb-afa0b7a54e5b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ceefbe38-518c-43bc-b3c8-8fa35b78e31c' class='xr-var-data-in' type='checkbox'><label for='data-ceefbe38-518c-43bc-b3c8-8fa35b78e31c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
-       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-c0f79e0d-5ec5-4462-be2f-f6fc3cc38aa7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c0f79e0d-5ec5-4462-be2f-f6fc3cc38aa7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3bf877a8-78fe-4f63-9aea-7f402525e89b' class='xr-var-data-in' type='checkbox'><label for='data-3bf877a8-78fe-4f63-9aea-7f402525e89b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-4b702e36-406c-4dac-b1c0-4a2650cf1556' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4b702e36-406c-4dac-b1c0-4a2650cf1556' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-013d0ce9-b47a-4f7d-8016-d5314154bb6a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-013d0ce9-b47a-4f7d-8016-d5314154bb6a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-888fab1b-440f-4ca5-9c6e-2c4ad8e49302' class='xr-var-data-in' type='checkbox'><label for='data-888fab1b-440f-4ca5-9c6e-2c4ad8e49302' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-e435988c-5bbc-474a-a5f3-1071c7e141a9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e435988c-5bbc-474a-a5f3-1071c7e141a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bb0a1796-0082-4893-84ae-5939c592be97' class='xr-var-data-in' type='checkbox'><label for='data-bb0a1796-0082-4893-84ae-5939c592be97' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
+       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-0d60109a-ad55-4776-8fe2-87b7b511bc84' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d60109a-ad55-4776-8fe2-87b7b511bc84' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6cc3d897-ed22-486c-a6d9-e478214c7521' class='xr-var-data-in' type='checkbox'><label for='data-6cc3d897-ed22-486c-a6d9-e478214c7521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -1658,7 +1658,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-48f1e7ad-fd07-4a62-a645-c4de7392dbd5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-48f1e7ad-fd07-4a62-a645-c4de7392dbd5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85acd956-7293-4ad3-99e1-b70767848f07' class='xr-var-data-in' type='checkbox'><label for='data-85acd956-7293-4ad3-99e1-b70767848f07' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b2f2351c-83e7-49e9-9f6c-8f3f972e2371' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b2f2351c-83e7-49e9-9f6c-8f3f972e2371' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b990127b-4bcc-454a-a3fb-7b1de0a9ccd8' class='xr-var-data-in' type='checkbox'><label for='data-b990127b-4bcc-454a-a3fb-7b1de0a9ccd8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-312d81ed-8e41-41b0-bf63-6f7113470b96' class='xr-section-summary-in' type='checkbox'  checked><label for='section-312d81ed-8e41-41b0-bf63-6f7113470b96' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-6c404cc6-3ce5-4d11-ae93-384e1b1d5b55' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c404cc6-3ce5-4d11-ae93-384e1b1d5b55' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-02924d2b-7ab6-4432-a2db-5f2cab41d300' class='xr-var-data-in' type='checkbox'><label for='data-02924d2b-7ab6-4432-a2db-5f2cab41d300' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c5343f40-d751-494b-b1ff-03ff7f5dcaa1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c5343f40-d751-494b-b1ff-03ff7f5dcaa1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64007276-0422-4048-adaf-94b4dd8adb84' class='xr-var-data-in' type='checkbox'><label for='data-64007276-0422-4048-adaf-94b4dd8adb84' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-407a9721-fa0e-481f-ba7a-3357eec7af3c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-407a9721-fa0e-481f-ba7a-3357eec7af3c' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 2700, x: 3600)>\n",
@@ -1679,7 +1679,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1706,7 +1706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -2070,19 +2070,19 @@
        "    latitude   (y, x) float64 -89.5 -89.5 -89.5 -89.5 ... 89.5 89.5 89.5 89.5\n",
        "Dimensions without coordinates: x, y\n",
        "Data variables:\n",
-       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-377f991b-96a2-4d19-8922-8ebc9ca97fe2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-377f991b-96a2-4d19-8922-8ebc9ca97fe2' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b416dac5-6664-4d7d-bc31-51ac70dbf0a6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b416dac5-6664-4d7d-bc31-51ac70dbf0a6' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-e1d842f0-03f2-4ef8-9088-3fbde383a25a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e1d842f0-03f2-4ef8-9088-3fbde383a25a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6528a51-e191-4ede-9681-6d13eecf8b12' class='xr-var-data-in' type='checkbox'><label for='data-e6528a51-e191-4ede-9681-6d13eecf8b12' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
+       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4c2ccfb1-44c0-441f-bc11-dc3daca388db' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4c2ccfb1-44c0-441f-bc11-dc3daca388db' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-41316d76-6085-43a7-8f92-a6292ddc41c5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-41316d76-6085-43a7-8f92-a6292ddc41c5' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-11b17cdd-ed63-40c7-a55d-f56f857056a9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-11b17cdd-ed63-40c7-a55d-f56f857056a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d986a80a-8afe-4359-924c-129fda7e1f0c' class='xr-var-data-in' type='checkbox'><label for='data-d986a80a-8afe-4359-924c-129fda7e1f0c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       ...,\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
-       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-f2d26fc8-784d-462b-abe7-ac45bb44c975' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f2d26fc8-784d-462b-abe7-ac45bb44c975' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb5acffe-90df-459e-9d60-f34bb7ba2e27' class='xr-var-data-in' type='checkbox'><label for='data-eb5acffe-90df-459e-9d60-f34bb7ba2e27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
+       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-6fe0b71a-f4c0-4188-b191-47768cd0687f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6fe0b71a-f4c0-4188-b191-47768cd0687f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f3e0e87-e715-43b4-82eb-a7d1bd92fab3' class='xr-var-data-in' type='checkbox'><label for='data-3f3e0e87-e715-43b4-82eb-a7d1bd92fab3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
        "       [-88.5, -88.5, -88.5, ..., -88.5, -88.5, -88.5],\n",
        "       [-87.5, -87.5, -87.5, ..., -87.5, -87.5, -87.5],\n",
        "       ...,\n",
        "       [ 87.5,  87.5,  87.5, ...,  87.5,  87.5,  87.5],\n",
        "       [ 88.5,  88.5,  88.5, ...,  88.5,  88.5,  88.5],\n",
-       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6d526e5b-0774-49fc-a77f-2a1f833c8e6a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6d526e5b-0774-49fc-a77f-2a1f833c8e6a' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-b3b1c7ee-6abd-4855-ba2b-62ed1b67ee0c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-b3b1c7ee-6abd-4855-ba2b-62ed1b67ee0c' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3fa3be49-861c-4432-b241-bf18dcfb0543' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3fa3be49-861c-4432-b241-bf18dcfb0543' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-7957a09c-31be-476f-a4d4-9f0838ee4943' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7957a09c-31be-476f-a4d4-9f0838ee4943' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2095,7 +2095,7 @@
        "    *empty*"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2122,7 +2122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -2187,14 +2187,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.54 s, sys: 1.53 s, total: 10.1 s\n",
+      "CPU times: user 8.5 s, sys: 1.66 s, total: 10.2 s\n",
       "Wall time: 10.5 s\n"
      ]
     },
@@ -2210,7 +2210,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2226,15 +2226,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 38.3 s, sys: 3.66 s, total: 41.9 s\n",
-      "Wall time: 42.4 s\n"
+      "CPU times: user 39.1 s, sys: 4.21 s, total: 43.3 s\n",
+      "Wall time: 43.8 s\n"
      ]
     },
     {
@@ -2249,7 +2249,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2265,15 +2265,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 8s, sys: 14.3 s, total: 3min 22s\n",
-      "Wall time: 3min 24s\n"
+      "CPU times: user 3min 11s, sys: 16.3 s, total: 3min 28s\n",
+      "Wall time: 3min 30s\n"
      ]
     },
     {
@@ -2288,7 +2288,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2329,7 +2329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2340,7 +2340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2351,7 +2351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2376,7 +2376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -2467,7 +2467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {

--- a/DocumentedExamples/Regridding.ipynb
+++ b/DocumentedExamples/Regridding.ipynb
@@ -27,7 +27,58 @@
     "import cartopy.crs as ccrs\n",
     "\n",
     "import xarray as xr\n",
+    "from dask.distributed import Client\n",
+    "\n",
     "import xesmf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load a `dask` client. This is not required for small regridding jobs, and does not affect the speed of generating the regridding weights, but may improve speed, or reduce memory overhead, when regridding large datasets with, for example, large time dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:32847</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://127.0.0.1:35023/status' target='_blank'>http://127.0.0.1:35023/status</a></li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>4</li>\n",
+       "  <li><b>Cores: </b>8</li>\n",
+       "  <li><b>Memory: </b>33.51 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://127.0.0.1:32847' processes=4 threads=8, memory=33.51 GB>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client = Client(n_workers=4)\n",
+    "client"
    ]
   },
   {
@@ -39,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +515,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c6340a68-f7a1-4e2d-91b3-5a9e9c6dac9f' class='xr-array-in' type='checkbox' checked><label for='section-c6340a68-f7a1-4e2d-91b3-5a9e9c6dac9f' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-264c9a72-defb-45a2-8552-a034fdea21e6' class='xr-array-in' type='checkbox' checked><label for='section-264c9a72-defb-45a2-8552-a034fdea21e6' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -558,8 +609,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-49561b8a-377b-402e-bd26-d48b862094aa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-49561b8a-377b-402e-bd26-d48b862094aa' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-0ee09a01-1844-4371-aa45-a4e50b23eb22' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0ee09a01-1844-4371-aa45-a4e50b23eb22' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0c4d6db7-6b4a-4cc7-8363-da748d4390a9' class='xr-var-data-in' type='checkbox'><label for='data-0c4d6db7-6b4a-4cc7-8363-da748d4390a9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-b1e8e76d-ea5e-4161-98ff-4870d35b1386' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b1e8e76d-ea5e-4161-98ff-4870d35b1386' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b23cca59-cdca-434f-acf6-7bde48188aab' class='xr-var-data-in' type='checkbox'><label for='data-b23cca59-cdca-434f-acf6-7bde48188aab' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
-       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-06832339-ec6e-4bea-8f03-a04d14216273' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-06832339-ec6e-4bea-8f03-a04d14216273' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6b1f214e-e428-4620-b8b4-bc42598bf6d2' class='xr-var-data-in' type='checkbox'><label for='data-6b1f214e-e428-4620-b8b4-bc42598bf6d2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-7ad132dc-623b-4720-8db4-2223187c04df' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7ad132dc-623b-4720-8db4-2223187c04df' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-5c8ee181-a9d4-44d8-8162-311edc3f6c83' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5c8ee181-a9d4-44d8-8162-311edc3f6c83' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9c5fe937-90ce-4477-90e3-fb9dd7aa8112' class='xr-var-data-in' type='checkbox'><label for='data-9c5fe937-90ce-4477-90e3-fb9dd7aa8112' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-c99cc94b-a91d-4de4-b7e3-a0407d13578f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c99cc94b-a91d-4de4-b7e3-a0407d13578f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bbec03da-9a1f-4448-bffb-12d5a735ed5b' class='xr-var-data-in' type='checkbox'><label for='data-bbec03da-9a1f-4448-bffb-12d5a735ed5b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
+       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-2c0d2536-84ce-408d-ae07-4650bbe50018' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c0d2536-84ce-408d-ae07-4650bbe50018' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0bbc911e-0a55-436a-9281-b5c342781114' class='xr-var-data-in' type='checkbox'><label for='data-0bbc911e-0a55-436a-9281-b5c342781114' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -582,7 +633,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ced2b44f-525d-4faa-a90e-4f1737866a02' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ced2b44f-525d-4faa-a90e-4f1737866a02' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8f2320b-b748-4e97-8a5f-310991eb4b9d' class='xr-var-data-in' type='checkbox'><label for='data-f8f2320b-b748-4e97-8a5f-310991eb4b9d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-953cb2c7-e688-42a7-aa2d-eb4c5da6badf' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-953cb2c7-e688-42a7-aa2d-eb4c5da6badf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ebd8b5c2-817e-471b-b764-0dcda087d716' class='xr-var-data-in' type='checkbox'><label for='data-ebd8b5c2-817e-471b-b764-0dcda087d716' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0f23811a-645c-43e1-97e3-4d1b6786373a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0f23811a-645c-43e1-97e3-4d1b6786373a' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-767b932e-089d-4de9-b8ef-5b9ae382090f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-767b932e-089d-4de9-b8ef-5b9ae382090f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-222a5a53-6c38-40f4-b0dd-e50d112890ad' class='xr-var-data-in' type='checkbox'><label for='data-222a5a53-6c38-40f4-b0dd-e50d112890ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-6ae5a5a4-d27c-4a5c-b367-96532803a406' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6ae5a5a4-d27c-4a5c-b367-96532803a406' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7c229ad5-9440-4b14-8724-a0954a8f986e' class='xr-var-data-in' type='checkbox'><label for='data-7c229ad5-9440-4b14-8724-a0954a8f986e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-915582a3-8744-44ab-b189-ec82c6d0f466' class='xr-section-summary-in' type='checkbox'  checked><label for='section-915582a3-8744-44ab-b189-ec82c6d0f466' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 300, x: 360)>\n",
@@ -603,7 +654,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -992,7 +1043,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-abecaa5f-be2b-40cc-a85d-100719e8cf57' class='xr-array-in' type='checkbox' checked><label for='section-abecaa5f-be2b-40cc-a85d-100719e8cf57' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-a908f197-636d-4c07-b61c-7989aa314ad1' class='xr-array-in' type='checkbox' checked><label for='section-a908f197-636d-4c07-b61c-7989aa314ad1' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1090,8 +1141,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-4fdce6a2-5035-473d-b1b9-481e47fe9434' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4fdce6a2-5035-473d-b1b9-481e47fe9434' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-3f9add76-964f-4d8a-a2ac-9b8ee4244459' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3f9add76-964f-4d8a-a2ac-9b8ee4244459' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bdf0ba54-4656-4779-916a-ad6bde4ca747' class='xr-var-data-in' type='checkbox'><label for='data-bdf0ba54-4656-4779-916a-ad6bde4ca747' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-ce5fc952-6c9d-4f50-b87e-2bbc88039c72' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ce5fc952-6c9d-4f50-b87e-2bbc88039c72' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d1d41d5-5059-4433-a801-3fada09904c6' class='xr-var-data-in' type='checkbox'><label for='data-6d1d41d5-5059-4433-a801-3fada09904c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
-       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-f55c8fe8-9ac0-457f-b6cc-641e88816185' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f55c8fe8-9ac0-457f-b6cc-641e88816185' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2f59f07f-c9dc-4868-9d63-a909519bb521' class='xr-var-data-in' type='checkbox'><label for='data-2f59f07f-c9dc-4868-9d63-a909519bb521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-67e43c26-ff09-4462-84aa-86374dc2bb26' class='xr-section-summary-in' type='checkbox'  checked><label for='section-67e43c26-ff09-4462-84aa-86374dc2bb26' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-a09934be-3d7a-40ab-95af-96ff9e6a2fd1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a09934be-3d7a-40ab-95af-96ff9e6a2fd1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b54d9db6-b116-41cc-b4bb-0814c3e114af' class='xr-var-data-in' type='checkbox'><label for='data-b54d9db6-b116-41cc-b4bb-0814c3e114af' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-dea62db8-ca9b-422b-9677-3c187fa81799' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-dea62db8-ca9b-422b-9677-3c187fa81799' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bf639703-1c99-49bd-80fb-878fe180bb9b' class='xr-var-data-in' type='checkbox'><label for='data-bf639703-1c99-49bd-80fb-878fe180bb9b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
+       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-7d44aa50-9af2-4962-a7ef-8bc5f1a4feef' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7d44aa50-9af2-4962-a7ef-8bc5f1a4feef' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ed01a89-d98a-4ac6-80cd-b679024895b3' class='xr-var-data-in' type='checkbox'><label for='data-5ed01a89-d98a-4ac6-80cd-b679024895b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 13, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 14, 0, 0, 0, 0),\n",
@@ -1114,7 +1165,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 14, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 14, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-711d18e4-67bb-4f0b-9442-c27728db4cf7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-711d18e4-67bb-4f0b-9442-c27728db4cf7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-904ffb6d-59b5-4993-81ff-445c49d5a699' class='xr-var-data-in' type='checkbox'><label for='data-904ffb6d-59b5-4993-81ff-445c49d5a699' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a1955f57-f59a-488b-aed0-67d249eafc37' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a1955f57-f59a-488b-aed0-67d249eafc37' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0664a50d-8eca-48c1-a1f8-8d0362bb30bb' class='xr-var-data-in' type='checkbox'><label for='data-0664a50d-8eca-48c1-a1f8-8d0362bb30bb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-cf9d8bb3-f7b1-4bf7-98ef-a944941987cc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cf9d8bb3-f7b1-4bf7-98ef-a944941987cc' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b698d4e2-674e-4b49-8e73-81b57e249281' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b698d4e2-674e-4b49-8e73-81b57e249281' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2c9cae8b-f80a-4407-968c-7c2d5f903012' class='xr-var-data-in' type='checkbox'><label for='data-2c9cae8b-f80a-4407-968c-7c2d5f903012' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-28488435-951f-49d0-9545-a8fbaff94cc9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-28488435-951f-49d0-9545-a8fbaff94cc9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7420bfc9-e684-427d-ab69-df30ea08110d' class='xr-var-data-in' type='checkbox'><label for='data-7420bfc9-e684-427d-ab69-df30ea08110d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-accc66a8-2a33-4acd-ae09-bf7234fb2762' class='xr-section-summary-in' type='checkbox'  checked><label for='section-accc66a8-2a33-4acd-ae09-bf7234fb2762' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 1080, x: 1440)>\n",
@@ -1135,7 +1186,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1152,7 +1203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1524,7 +1575,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-c03222dc-3caf-4b0a-b87a-ddbeb150effd' class='xr-array-in' type='checkbox' checked><label for='section-c03222dc-3caf-4b0a-b87a-ddbeb150effd' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-34e5e75a-128d-42ae-adfe-4f895795bd12' class='xr-array-in' type='checkbox' checked><label for='section-34e5e75a-128d-42ae-adfe-4f895795bd12' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1634,8 +1685,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-4b702e36-406c-4dac-b1c0-4a2650cf1556' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4b702e36-406c-4dac-b1c0-4a2650cf1556' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-013d0ce9-b47a-4f7d-8016-d5314154bb6a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-013d0ce9-b47a-4f7d-8016-d5314154bb6a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-888fab1b-440f-4ca5-9c6e-2c4ad8e49302' class='xr-var-data-in' type='checkbox'><label for='data-888fab1b-440f-4ca5-9c6e-2c4ad8e49302' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-e435988c-5bbc-474a-a5f3-1071c7e141a9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e435988c-5bbc-474a-a5f3-1071c7e141a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bb0a1796-0082-4893-84ae-5939c592be97' class='xr-var-data-in' type='checkbox'><label for='data-bb0a1796-0082-4893-84ae-5939c592be97' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
-       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-0d60109a-ad55-4776-8fe2-87b7b511bc84' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d60109a-ad55-4776-8fe2-87b7b511bc84' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6cc3d897-ed22-486c-a6d9-e478214c7521' class='xr-var-data-in' type='checkbox'><label for='data-6cc3d897-ed22-486c-a6d9-e478214c7521' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-c07b19eb-c1a2-47c6-b607-9564f53b1249' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c07b19eb-c1a2-47c6-b607-9564f53b1249' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-ae611405-bc4d-48c4-9003-09a8e49b865a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae611405-bc4d-48c4-9003-09a8e49b865a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa6e8138-148e-42c7-bde3-d0950b8b8f42' class='xr-var-data-in' type='checkbox'><label for='data-fa6e8138-148e-42c7-bde3-d0950b8b8f42' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-a2da410f-4181-4d0c-8360-7ea2b542cd06' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a2da410f-4181-4d0c-8360-7ea2b542cd06' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f43c4b16-0da7-45e5-9df2-09fa7ba601c4' class='xr-var-data-in' type='checkbox'><label for='data-f43c4b16-0da7-45e5-9df2-09fa7ba601c4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
+       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-d32365ad-79e3-423f-baa4-f7a5046e1719' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d32365ad-79e3-423f-baa4-f7a5046e1719' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b03466dd-5d8e-4799-9caa-ae51484b2f65' class='xr-var-data-in' type='checkbox'><label for='data-b03466dd-5d8e-4799-9caa-ae51484b2f65' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -1658,7 +1709,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-6c404cc6-3ce5-4d11-ae93-384e1b1d5b55' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6c404cc6-3ce5-4d11-ae93-384e1b1d5b55' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-02924d2b-7ab6-4432-a2db-5f2cab41d300' class='xr-var-data-in' type='checkbox'><label for='data-02924d2b-7ab6-4432-a2db-5f2cab41d300' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c5343f40-d751-494b-b1ff-03ff7f5dcaa1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c5343f40-d751-494b-b1ff-03ff7f5dcaa1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-64007276-0422-4048-adaf-94b4dd8adb84' class='xr-var-data-in' type='checkbox'><label for='data-64007276-0422-4048-adaf-94b4dd8adb84' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-407a9721-fa0e-481f-ba7a-3357eec7af3c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-407a9721-fa0e-481f-ba7a-3357eec7af3c' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2908af33-a0a6-486b-b311-ab4cdcd83c47' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2908af33-a0a6-486b-b311-ab4cdcd83c47' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a011416f-afff-45ed-a05f-aa253570140a' class='xr-var-data-in' type='checkbox'><label for='data-a011416f-afff-45ed-a05f-aa253570140a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c624dfd5-8d3d-4dc3-ae58-607d97fdb362' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c624dfd5-8d3d-4dc3-ae58-607d97fdb362' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-683751a5-9d5d-482e-8451-8d752d85e434' class='xr-var-data-in' type='checkbox'><label for='data-683751a5-9d5d-482e-8451-8d752d85e434' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-868574ba-c2c9-4aaf-a32e-49da12fd7bff' class='xr-section-summary-in' type='checkbox'  checked><label for='section-868574ba-c2c9-4aaf-a32e-49da12fd7bff' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 2700, x: 3600)>\n",
@@ -1679,7 +1730,7 @@
        "    standard_name:  sea_surface_height_above_geoid"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1706,7 +1757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -2070,19 +2121,19 @@
        "    latitude   (y, x) float64 -89.5 -89.5 -89.5 -89.5 ... 89.5 89.5 89.5 89.5\n",
        "Dimensions without coordinates: x, y\n",
        "Data variables:\n",
-       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4c2ccfb1-44c0-441f-bc11-dc3daca388db' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4c2ccfb1-44c0-441f-bc11-dc3daca388db' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-41316d76-6085-43a7-8f92-a6292ddc41c5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-41316d76-6085-43a7-8f92-a6292ddc41c5' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-11b17cdd-ed63-40c7-a55d-f56f857056a9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-11b17cdd-ed63-40c7-a55d-f56f857056a9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d986a80a-8afe-4359-924c-129fda7e1f0c' class='xr-var-data-in' type='checkbox'><label for='data-d986a80a-8afe-4359-924c-129fda7e1f0c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
+       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-3c86d900-0638-4fad-a1b7-5d126e196b88' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3c86d900-0638-4fad-a1b7-5d126e196b88' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-566faf70-64a1-4507-9947-0ea407b32c30' class='xr-section-summary-in' type='checkbox'  checked><label for='section-566faf70-64a1-4507-9947-0ea407b32c30' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-724f1caa-1265-4f54-a669-d65f0fc214a4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-724f1caa-1265-4f54-a669-d65f0fc214a4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-858cb76b-f356-48cd-a93e-6e1eb5586438' class='xr-var-data-in' type='checkbox'><label for='data-858cb76b-f356-48cd-a93e-6e1eb5586438' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       ...,\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
-       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-6fe0b71a-f4c0-4188-b191-47768cd0687f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6fe0b71a-f4c0-4188-b191-47768cd0687f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f3e0e87-e715-43b4-82eb-a7d1bd92fab3' class='xr-var-data-in' type='checkbox'><label for='data-3f3e0e87-e715-43b4-82eb-a7d1bd92fab3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
+       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-1cceade0-1803-4931-b93f-6e07373fdd5f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1cceade0-1803-4931-b93f-6e07373fdd5f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8040a15e-b21b-46a6-b370-48fc5df4bb06' class='xr-var-data-in' type='checkbox'><label for='data-8040a15e-b21b-46a6-b370-48fc5df4bb06' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
        "       [-88.5, -88.5, -88.5, ..., -88.5, -88.5, -88.5],\n",
        "       [-87.5, -87.5, -87.5, ..., -87.5, -87.5, -87.5],\n",
        "       ...,\n",
        "       [ 87.5,  87.5,  87.5, ...,  87.5,  87.5,  87.5],\n",
        "       [ 88.5,  88.5,  88.5, ...,  88.5,  88.5,  88.5],\n",
-       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3fa3be49-861c-4432-b241-bf18dcfb0543' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3fa3be49-861c-4432-b241-bf18dcfb0543' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-7957a09c-31be-476f-a4d4-9f0838ee4943' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7957a09c-31be-476f-a4d4-9f0838ee4943' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-c1a128a1-33a2-47ab-8e25-b88eb9fb117b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c1a128a1-33a2-47ab-8e25-b88eb9fb117b' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-43ffa651-41d1-4edd-8621-52a1225bdf8b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-43ffa651-41d1-4edd-8621-52a1225bdf8b' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2095,7 +2146,7 @@
        "    *empty*"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2122,7 +2173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -2187,15 +2238,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.5 s, sys: 1.66 s, total: 10.2 s\n",
-      "Wall time: 10.5 s\n"
+      "CPU times: user 9.08 s, sys: 1.66 s, total: 10.7 s\n",
+      "Wall time: 10.4 s\n"
      ]
     },
     {
@@ -2210,7 +2261,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2226,15 +2277,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 39.1 s, sys: 4.21 s, total: 43.3 s\n",
-      "Wall time: 43.8 s\n"
+      "CPU times: user 40.9 s, sys: 4.52 s, total: 45.4 s\n",
+      "Wall time: 43.5 s\n"
      ]
     },
     {
@@ -2249,7 +2300,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2265,15 +2316,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 11s, sys: 16.3 s, total: 3min 28s\n",
-      "Wall time: 3min 30s\n"
+      "CPU times: user 3min 23s, sys: 19.5 s, total: 3min 43s\n",
+      "Wall time: 3min 34s\n"
      ]
     },
     {
@@ -2288,7 +2339,7 @@
        "Periodic in longitude?      True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2329,7 +2380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2340,7 +2391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2351,10 +2402,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 47.4 ms, sys: 4.71 ms, total: 52.1 ms\n",
+      "Wall time: 47.2 ms\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "ssh_010_regridded = regridder_010degACCESSOM2_1deg(ssh_010.chunk({'x': None, 'y': None, 'time': 2}))\n",
     "ssh_010_regridded = ssh_010_regridded.assign_coords({'x': ds_out.longitude[0, :], 'y': ds_out.latitude[:, 0]})\n",
     "ssh_010_regridded = ssh_010_regridded.rename({'x': 'longitude', 'y': 'latitude'})"
@@ -2376,7 +2437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -2467,7 +2528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {

--- a/DocumentedExamples/Regridding.ipynb
+++ b/DocumentedExamples/Regridding.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Re-gridding output\n",
     "\n",
-    "This notebook how we can regrid the ACCESS-OM2 output onto a different grid. In particular, we demonstrate how we can take model output from all three ACCESS-OM2 resolutions and regrid them onto a 1 degree longitude-latitude grid.\n",
+    "This notebook demonstrates regridding the ACCESS-OM2 output onto a different grid. In particular, regridding model output from all three ACCESS-OM2 resolutions on to the same 1 degree rectilinear longitude-latitude grid.\n",
     "\n",
     "**Requirements:** The `conda/analysis3-21.01` (or later) module on VDI/gadi (or your own up-to-date cookbook installation).\n",
     "\n",
@@ -25,19 +25,6 @@
     "import cosima_cookbook as cc\n",
     "import matplotlib.pyplot as plt\n",
     "import cartopy.crs as ccrs\n",
-    "import numpy as np\n",
-    "import cmocean as cm\n",
-    "from dask.distributed import Client\n",
-    "\n",
-    "import matplotlib\n",
-    "from matplotlib import rc\n",
-    "rc('font',**{'family':'sans-serif'})\n",
-    "rc('text', usetex=True)\n",
-    "matplotlib.rcParams['text.latex.preamble'] = [\n",
-    "    r'\\usepackage{amsmath}',\n",
-    "    r'\\usepackage{amsfonts}',\n",
-    "    r'\\usepackage{amssymb}']\n",
-    "rc('text', usetex=False)\n",
     "\n",
     "import xarray as xr\n",
     "import xesmf"
@@ -47,61 +34,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load a `dask` client."
+    "Create a `session` for `cosima-cookbook`. Here we use a `session` with the default database."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table style=\"border: 2px solid white;\">\n",
-       "<tr>\n",
-       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
-       "<h3 style=\"text-align: left;\">Client</h3>\n",
-       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://127.0.0.1:34417</li>\n",
-       "  <li><b>Dashboard: </b><a href='/proxy/32903/status' target='_blank'>/proxy/32903/status</a></li>\n",
-       "</ul>\n",
-       "</td>\n",
-       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
-       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
-       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>4</li>\n",
-       "  <li><b>Cores: </b>48</li>\n",
-       "  <li><b>Memory: </b>202.48 GB</li>\n",
-       "</ul>\n",
-       "</td>\n",
-       "</tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Client: 'tcp://127.0.0.1:34417' processes=4 threads=48, memory=202.48 GB>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client = Client(n_workers=4)\n",
-    "client"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And also create a `session` for `cosima-cookbook`. Here we use a `session` with the default database."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we load the grid parameters for each resolution. We use `.reset_coords()` and `.drop()` on some grids to bring them in the format that the `xesmf` package needs."
+    "Next we load the grid parameters for each resolution. We use `.reset_coords()`, `.drop()` and `.rename()` on some grids to make them compatible with the `xesmf` package requirements."
    ]
   },
   {
@@ -149,7 +87,7 @@
     "We use the `cosima-cookbok` functionality to load our variables. In particular, we use the `querying.getvar()` function. (Type `?cc.querying.getvar` for the function's docstring.)\n",
     "\n",
     "\n",
-    "We make sure to assign the correct tripolar coordinates as `coords`. Since sea-surface height is lives on `t`-cells, we add `geolon_t` and `geolat_t`. We also rename them to `longitude` and `latitude` to ease our life further down (`xesfm` package that we will use for regridding automatically searches for coordinates named `longitude` and `latitude`.)"
+    "We make sure to assign the correct tripolar coordinates as `coords`. Since sea-surface height is lives on `t`-cells, we add `geolon_t` and `geolat_t`. We also rename them to `longitude` and `latitude` to ease our life further down (`xesmf` package that we will use for regridding automatically searches for coordinates named `longitude` and `latitude`.)"
    ]
   },
   {
@@ -526,7 +464,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-ae688a4c-83f3-410e-910d-9c73da65b603' class='xr-array-in' type='checkbox' checked><label for='section-ae688a4c-83f3-410e-910d-9c73da65b603' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 300</li><li><span class='xr-has-index'>x</span>: 360</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-f90b1da8-1b8f-4ce3-9345-ef8367705d75' class='xr-array-in' type='checkbox' checked><label for='section-f90b1da8-1b8f-4ce3-9345-ef8367705d75' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 300, 360), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -620,8 +558,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-34c16696-4cc7-4511-827a-6be3858411b8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-34c16696-4cc7-4511-827a-6be3858411b8' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-68387cb4-6e17-44ca-b9de-c1cdac448a81' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-68387cb4-6e17-44ca-b9de-c1cdac448a81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1fa34cc2-24ef-4dd5-a7bb-8e2558e6eba3' class='xr-var-data-in' type='checkbox'><label for='data-1fa34cc2-24ef-4dd5-a7bb-8e2558e6eba3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-ee50b61e-5d58-4ff1-8627-41df8643f0ed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ee50b61e-5d58-4ff1-8627-41df8643f0ed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b9be6b24-53cc-4576-8133-b3ba26de209b' class='xr-var-data-in' type='checkbox'><label for='data-b9be6b24-53cc-4576-8133-b3ba26de209b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
-       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-e8a12469-a866-45c3-bb00-afd4d617a95c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e8a12469-a866-45c3-bb00-afd4d617a95c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-500cb425-7fd0-44b1-aa68-dc303ae59a46' class='xr-var-data-in' type='checkbox'><label for='data-500cb425-7fd0-44b1-aa68-dc303ae59a46' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-5022b4cc-b0fa-4147-9005-a5665f5ad6b0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5022b4cc-b0fa-4147-9005-a5665f5ad6b0' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-f036dbd9-af71-46a8-b216-dcecae7f3209' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f036dbd9-af71-46a8-b216-dcecae7f3209' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ba4693b0-1061-41d3-81c1-2bc459d01c54' class='xr-var-data-in' type='checkbox'><label for='data-ba4693b0-1061-41d3-81c1-2bc459d01c54' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-77.88 -77.63 ... 89.32 89.77</div><input id='attrs-f34b9120-076e-480d-870d-5f091943d4a7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f34b9120-076e-480d-870d-5f091943d4a7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d22d7913-5066-499f-84f7-8677540443d5' class='xr-var-data-in' type='checkbox'><label for='data-d22d7913-5066-499f-84f7-8677540443d5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-77.876623, -77.629713, -77.381707, ...,  88.872933,  89.324006,\n",
+       "        89.774476])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-f11bff45-ab41-41ec-ac45-6298749a79f4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f11bff45-ab41-41ec-ac45-6298749a79f4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33389e47-2ff8-42f1-8971-dd2be01414dd' class='xr-var-data-in' type='checkbox'><label for='data-33389e47-2ff8-42f1-8971-dd2be01414dd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -644,7 +582,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-8d0af74d-1776-4583-bc9f-dbdac2141a5d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8d0af74d-1776-4583-bc9f-dbdac2141a5d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-118c085f-8387-48e2-8c3e-84092b6c3d02' class='xr-var-data-in' type='checkbox'><label for='data-118c085f-8387-48e2-8c3e-84092b6c3d02' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-2100e290-a41f-40b1-a83e-960cabeb3811' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2100e290-a41f-40b1-a83e-960cabeb3811' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e7b94464-5a9e-4a8d-b3f2-409caf6f398b' class='xr-var-data-in' type='checkbox'><label for='data-e7b94464-5a9e-4a8d-b3f2-409caf6f398b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6cd0cd22-73ea-4544-a197-ce95b76c0ef4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6cd0cd22-73ea-4544-a197-ce95b76c0ef4' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-340b7a06-c071-4059-9b6f-b866febea842' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-340b7a06-c071-4059-9b6f-b866febea842' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0b95980-8621-4acd-aeb2-7aaa1fed888e' class='xr-var-data-in' type='checkbox'><label for='data-e0b95980-8621-4acd-aeb2-7aaa1fed888e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d06f840a-9c2c-47d2-9656-00fd473fd209' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d06f840a-9c2c-47d2-9656-00fd473fd209' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3e3eb4b8-87c2-49fa-91c9-3795678ca5ad' class='xr-var-data-in' type='checkbox'><label for='data-3e3eb4b8-87c2-49fa-91c9-3795678ca5ad' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[108000 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-0e6b2c15-3528-4ed0-840c-0f280de1dfd0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-0e6b2c15-3528-4ed0-840c-0f280de1dfd0' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 300, x: 360)>\n",
@@ -671,8 +609,8 @@
     }
    ],
    "source": [
-    "ssh_1 = cc.querying.getvar('1deg_jra55v13_iaf_spinup1_B1', variable='sea_level', session=session, frequency='1 monthly',\n",
-    "                           start_time='2000-01-01', end_time='2001-12-31')\n",
+    "ssh_1 = cc.querying.getvar('1deg_jra55v13_iaf_spinup1_B1', variable='sea_level', session=session, \n",
+    "                           frequency='1 monthly', start_time='2000-01-01', end_time='2001-12-31')\n",
     "ssh_1 = ssh_1.sel(time=slice('2000', '2001'))\n",
     "ssh_1 = ssh_1.assign_coords({'geolat_t': grid1.geolat_t, 'geolon_t': grid1.geolon_t})\n",
     "ssh_1 = ssh_1.rename({'xt_ocean': 'x', 'yt_ocean': 'y',\n",
@@ -1054,7 +992,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-894c0d7b-c577-432c-9566-9d114fc3ce3d' class='xr-array-in' type='checkbox' checked><label for='section-894c0d7b-c577-432c-9566-9d114fc3ce3d' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 1080</li><li><span class='xr-has-index'>x</span>: 1440</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-6a4ec635-1edf-44d4-905e-f9e7631920bb' class='xr-array-in' type='checkbox' checked><label for='section-6a4ec635-1edf-44d4-905e-f9e7631920bb' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1152,8 +1090,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-afe49606-e18c-47a3-82af-da8290275ba4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-afe49606-e18c-47a3-82af-da8290275ba4' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-5af83c7d-eda7-47e3-935b-195f8fd2beb6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5af83c7d-eda7-47e3-935b-195f8fd2beb6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-202576e7-eca1-4351-b523-3fd03fc21676' class='xr-var-data-in' type='checkbox'><label for='data-202576e7-eca1-4351-b523-3fd03fc21676' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-4dcca31a-7967-4151-a37d-bb48297df84b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4dcca31a-7967-4151-a37d-bb48297df84b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e0daae2b-fe47-467a-90fa-8e4b885e9474' class='xr-var-data-in' type='checkbox'><label for='data-e0daae2b-fe47-467a-90fa-8e4b885e9474' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
-       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-2241a3ae-25f4-4dd0-bf23-b7203b12601d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2241a3ae-25f4-4dd0-bf23-b7203b12601d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6d8992fe-ad8f-43b0-b57e-51d7d670c0c5' class='xr-var-data-in' type='checkbox'><label for='data-6d8992fe-ad8f-43b0-b57e-51d7d670c0c5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-bd3ad6bd-6288-4acd-a674-e8e55a11044f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-bd3ad6bd-6288-4acd-a674-e8e55a11044f' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.6 ... 79.62 79.88</div><input id='attrs-eff94347-a0d5-4970-b538-049acd4561b5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eff94347-a0d5-4970-b538-049acd4561b5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-17315ae2-0da9-4397-b869-8ff8884dfbea' class='xr-var-data-in' type='checkbox'><label for='data-17315ae2-0da9-4397-b869-8ff8884dfbea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.875, -279.625, -279.375, ...,   79.375,   79.625,   79.875])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.08 -80.97 ... 89.84 89.95</div><input id='attrs-638a7d20-d8ed-4e4e-949c-f8bb54194aa3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-638a7d20-d8ed-4e4e-949c-f8bb54194aa3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fbaa8891-34ad-40e4-92c5-d255a717380c' class='xr-var-data-in' type='checkbox'><label for='data-fbaa8891-34ad-40e4-92c5-d255a717380c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.077001, -80.971402, -80.865804, ...,  89.736085,  89.841684,\n",
+       "        89.947282])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-14 12:00:00 ... 2001-12-...</div><input id='attrs-11759271-aea7-416f-ae52-4edde637ede6' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-11759271-aea7-416f-ae52-4edde637ede6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d21a3e44-3417-44ff-98ae-88fe16e3a420' class='xr-var-data-in' type='checkbox'><label for='data-d21a3e44-3417-44ff-98ae-88fe16e3a420' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 13, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 14, 0, 0, 0, 0),\n",
@@ -1176,7 +1114,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 14, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 14, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 14, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ade08df1-9a98-4f23-85c6-d49e073474f9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ade08df1-9a98-4f23-85c6-d49e073474f9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-22783064-3da2-4007-9e43-56f0c0f652c6' class='xr-var-data-in' type='checkbox'><label for='data-22783064-3da2-4007-9e43-56f0c0f652c6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b7197094-f7af-471f-83bc-8609e8eadf27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b7197094-f7af-471f-83bc-8609e8eadf27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9174c71d-6094-4a80-851f-4c27dccf8575' class='xr-var-data-in' type='checkbox'><label for='data-9174c71d-6094-4a80-851f-4c27dccf8575' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-85b7b4c6-e266-40b6-bce4-e4fd05bf5444' class='xr-section-summary-in' type='checkbox'  checked><label for='section-85b7b4c6-e266-40b6-bce4-e4fd05bf5444' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 14, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-bd3355b6-5ae7-4fd2-8e0d-9df585c0cae4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bd3355b6-5ae7-4fd2-8e0d-9df585c0cae4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d175f728-c50e-472e-8369-e409c9e6c173' class='xr-var-data-in' type='checkbox'><label for='data-d175f728-c50e-472e-8369-e409c9e6c173' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>valid_range :</span></dt><dd>[-91.  91.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-4e0b58fc-7b3f-4949-b920-cc1c1ce0956f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4e0b58fc-7b3f-4949-b920-cc1c1ce0956f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e8ed91a-4658-4af0-868d-1793158d9fa1' class='xr-var-data-in' type='checkbox'><label for='data-0e8ed91a-4658-4af0-868d-1793158d9fa1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tracer longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>valid_range :</span></dt><dd>[-281.  361.]</dd><dt><span>cell_methods :</span></dt><dd>time: point</dd></dl></div><div class='xr-var-data'><pre>[1555200 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2c05b4aa-b10b-4f5d-a102-707dfb446381' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2c05b4aa-b10b-4f5d-a102-707dfb446381' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 1080, x: 1440)>\n",
@@ -1203,8 +1141,8 @@
     }
    ],
    "source": [
-    "ssh_025 = cc.querying.getvar('025deg_jra55v13_iaf_gmredi6', variable='sea_level', session=session, frequency='1 monthly',\n",
-    "                             start_time='2000-01-01', end_time='2001-12-31')\n",
+    "ssh_025 = cc.querying.getvar('025deg_jra55v13_iaf_gmredi6', variable='sea_level', session=session, \n",
+    "                             frequency='1 monthly', start_time='2000-01-01', end_time='2001-12-31')\n",
     "ssh_025 = ssh_025.sel(time=slice('2000', '2001'))\n",
     "ssh_025 = ssh_025.assign_coords({'geolat_t': grid025.geolat_t, 'geolon_t': grid025.geolon_t})\n",
     "ssh_025 = ssh_025.rename({'xt_ocean': 'x', 'yt_ocean': 'y',\n",
@@ -1586,7 +1524,7 @@
        "    cell_methods:   time: mean\n",
        "    time_avg_info:  average_T1,average_T2,average_DT\n",
        "    coordinates:    geolon_t geolat_t\n",
-       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-b1ca5924-1b1d-4a7e-a80d-04d9304a8817' class='xr-array-in' type='checkbox' checked><label for='section-b1ca5924-1b1d-4a7e-a80d-04d9304a8817' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
+       "    standard_name:  sea_surface_height_above_geoid</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'sea_level'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 24</li><li><span class='xr-has-index'>y</span>: 2700</li><li><span class='xr-has-index'>x</span>: 3600</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-9d1781a8-1d1a-4a52-8dac-0bd4ea4ffd22' class='xr-array-in' type='checkbox' checked><label for='section-9d1781a8-1d1a-4a52-8dac-0bd4ea4ffd22' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>dask.array&lt;chunksize=(1, 540, 720), meta=np.ndarray&gt;</span></div><div class='xr-array-data'><table>\n",
        "<tr>\n",
        "<td>\n",
        "<table>\n",
@@ -1696,8 +1634,8 @@
        "</svg>\n",
        "</td>\n",
        "</tr>\n",
-       "</table></div></div></li><li class='xr-section-item'><input id='section-15dcd55f-1ffe-4230-bcfd-b2a434e62859' class='xr-section-summary-in' type='checkbox'  checked><label for='section-15dcd55f-1ffe-4230-bcfd-b2a434e62859' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-707e52f7-b21c-47df-a471-3d6d8da52090' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-707e52f7-b21c-47df-a471-3d6d8da52090' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-20801ec4-0008-4ce1-a9e6-a263c426b946' class='xr-var-data-in' type='checkbox'><label for='data-20801ec4-0008-4ce1-a9e6-a263c426b946' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-e9518e92-bae7-4db4-a444-fc29fc2ecc67' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e9518e92-bae7-4db4-a444-fc29fc2ecc67' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3ac47570-2283-4237-8b21-801ab8d47cbb' class='xr-var-data-in' type='checkbox'><label for='data-3ac47570-2283-4237-8b21-801ab8d47cbb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
-       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-0f6a8d79-2198-4ca2-a6a9-757e88bd34ae' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0f6a8d79-2198-4ca2-a6a9-757e88bd34ae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-43e495f8-7073-4b2f-8840-24a21efbf9c4' class='xr-var-data-in' type='checkbox'><label for='data-43e495f8-7073-4b2f-8840-24a21efbf9c4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
+       "</table></div></div></li><li class='xr-section-item'><input id='section-a115a9d8-7cdd-4bec-b3b3-e62c01b6e35f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a115a9d8-7cdd-4bec-b3b3-e62c01b6e35f' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.9 -279.8 ... 79.85 79.95</div><input id='attrs-f70efd68-f37f-4b1a-b4ec-c265f6ccca3b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f70efd68-f37f-4b1a-b4ec-c265f6ccca3b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-10cabbc2-9779-4f63-9d25-8bc9405b5c6d' class='xr-var-data-in' type='checkbox'><label for='data-10cabbc2-9779-4f63-9d25-8bc9405b5c6d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell longitude</dd><dt><span>units :</span></dt><dd>degrees_E</dd><dt><span>cartesian_axis :</span></dt><dd>X</dd></dl></div><div class='xr-var-data'><pre>array([-279.95, -279.85, -279.75, ...,   79.75,   79.85,   79.95])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-81.11 -81.07 ... 89.94 89.98</div><input id='attrs-e424ac6a-571a-4567-a2eb-afa0b7a54e5b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e424ac6a-571a-4567-a2eb-afa0b7a54e5b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ceefbe38-518c-43bc-b3c8-8fa35b78e31c' class='xr-var-data-in' type='checkbox'><label for='data-ceefbe38-518c-43bc-b3c8-8fa35b78e31c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>tcell latitude</dd><dt><span>units :</span></dt><dd>degrees_N</dd><dt><span>cartesian_axis :</span></dt><dd>Y</dd></dl></div><div class='xr-var-data'><pre>array([-81.108632, -81.066392, -81.024153, ...,  89.894417,  89.936657,\n",
+       "        89.978896])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>2000-01-16 12:00:00 ... 2001-12-...</div><input id='attrs-c0f79e0d-5ec5-4462-be2f-f6fc3cc38aa7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c0f79e0d-5ec5-4462-be2f-f6fc3cc38aa7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3bf877a8-78fe-4f63-9aea-7f402525e89b' class='xr-var-data-in' type='checkbox'><label for='data-3bf877a8-78fe-4f63-9aea-7f402525e89b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>time</dd><dt><span>cartesian_axis :</span></dt><dd>T</dd><dt><span>calendar_type :</span></dt><dd>GREGORIAN</dd><dt><span>bounds :</span></dt><dd>time_bounds</dd></dl></div><div class='xr-var-data'><pre>array([cftime.DatetimeGregorian(2000, 1, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 2, 15, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 3, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2000, 4, 16, 0, 0, 0, 0),\n",
@@ -1720,7 +1658,7 @@
        "       cftime.DatetimeGregorian(2001, 9, 16, 0, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 10, 16, 12, 0, 0, 0),\n",
        "       cftime.DatetimeGregorian(2001, 11, 16, 0, 0, 0, 0),\n",
-       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d07b84c3-d492-406f-9cd7-cc628feec30b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d07b84c3-d492-406f-9cd7-cc628feec30b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec4acffa-b436-4ca4-ba56-b58047f104cd' class='xr-var-data-in' type='checkbox'><label for='data-ec4acffa-b436-4ca4-ba56-b58047f104cd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-c68822bd-864a-44f5-b5e3-937ebc94c541' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c68822bd-864a-44f5-b5e3-937ebc94c541' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83c3b548-89c3-4f61-8183-00e696437be3' class='xr-var-data-in' type='checkbox'><label for='data-83c3b548-89c3-4f61-8183-00e696437be3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-68ea0e59-69cb-487c-90d2-8173509fae92' class='xr-section-summary-in' type='checkbox'  checked><label for='section-68ea0e59-69cb-487c-90d2-8173509fae92' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
+       "       cftime.DatetimeGregorian(2001, 12, 16, 12, 0, 0, 0)], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-48f1e7ad-fd07-4a62-a645-c4de7392dbd5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-48f1e7ad-fd07-4a62-a645-c4de7392dbd5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85acd956-7293-4ad3-99e1-b70767848f07' class='xr-var-data-in' type='checkbox'><label for='data-85acd956-7293-4ad3-99e1-b70767848f07' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic latitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_N</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-b2f2351c-83e7-49e9-9f6c-8f3f972e2371' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b2f2351c-83e7-49e9-9f6c-8f3f972e2371' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b990127b-4bcc-454a-a3fb-7b1de0a9ccd8' class='xr-var-data-in' type='checkbox'><label for='data-b990127b-4bcc-454a-a3fb-7b1de0a9ccd8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Geographic longitude of T_cell centers</dd><dt><span>units :</span></dt><dd>degrees_E</dd></dl></div><div class='xr-var-data'><pre>[9720000 values with dtype=float64]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-312d81ed-8e41-41b0-bf63-6f7113470b96' class='xr-section-summary-in' type='checkbox'  checked><label for='section-312d81ed-8e41-41b0-bf63-6f7113470b96' class='xr-section-summary' >Attributes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>effective sea level (eta_t + patm/(rho0*g)) on T cells</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>valid_range :</span></dt><dd>[-1000.  1000.]</dd><dt><span>cell_methods :</span></dt><dd>time: mean</dd><dt><span>time_avg_info :</span></dt><dd>average_T1,average_T2,average_DT</dd><dt><span>coordinates :</span></dt><dd>geolon_t geolat_t</dd><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'sea_level' (time: 24, y: 2700, x: 3600)>\n",
@@ -2132,19 +2070,19 @@
        "    latitude   (y, x) float64 -89.5 -89.5 -89.5 -89.5 ... 89.5 89.5 89.5 89.5\n",
        "Dimensions without coordinates: x, y\n",
        "Data variables:\n",
-       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1a5e3a6c-422e-4fae-8061-ed881024cd6c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1a5e3a6c-422e-4fae-8061-ed881024cd6c' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4b1ad1d3-cf10-45d6-b417-3f3d8dec762e' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4b1ad1d3-cf10-45d6-b417-3f3d8dec762e' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-6c5b3c75-b6ef-48c1-bb6a-c0875204e93e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6c5b3c75-b6ef-48c1-bb6a-c0875204e93e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d1e8c5ab-2e85-43f0-8017-bf4fb351a225' class='xr-var-data-in' type='checkbox'><label for='data-d1e8c5ab-2e85-43f0-8017-bf4fb351a225' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
+       "    *empty*</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-377f991b-96a2-4d19-8922-8ebc9ca97fe2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-377f991b-96a2-4d19-8922-8ebc9ca97fe2' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>x</span>: 360</li><li><span>y</span>: 180</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b416dac5-6664-4d7d-bc31-51ac70dbf0a6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b416dac5-6664-4d7d-bc31-51ac70dbf0a6' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>longitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-279.5 -278.5 -277.5 ... 78.5 79.5</div><input id='attrs-e1d842f0-03f2-4ef8-9088-3fbde383a25a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e1d842f0-03f2-4ef8-9088-3fbde383a25a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e6528a51-e191-4ede-9681-6d13eecf8b12' class='xr-var-data-in' type='checkbox'><label for='data-e6528a51-e191-4ede-9681-6d13eecf8b12' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       ...,\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
        "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5],\n",
-       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-c448fea6-bc81-4f4c-acf2-805a29710c0e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c448fea6-bc81-4f4c-acf2-805a29710c0e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21f8fa63-5943-4913-ab67-0dfc82814a26' class='xr-var-data-in' type='checkbox'><label for='data-21f8fa63-5943-4913-ab67-0dfc82814a26' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
+       "       [-279.5, -278.5, -277.5, ...,   77.5,   78.5,   79.5]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>latitude</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-89.5 -89.5 -89.5 ... 89.5 89.5</div><input id='attrs-f2d26fc8-784d-462b-abe7-ac45bb44c975' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f2d26fc8-784d-462b-abe7-ac45bb44c975' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb5acffe-90df-459e-9d60-f34bb7ba2e27' class='xr-var-data-in' type='checkbox'><label for='data-eb5acffe-90df-459e-9d60-f34bb7ba2e27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([[-89.5, -89.5, -89.5, ..., -89.5, -89.5, -89.5],\n",
        "       [-88.5, -88.5, -88.5, ..., -88.5, -88.5, -88.5],\n",
        "       [-87.5, -87.5, -87.5, ..., -87.5, -87.5, -87.5],\n",
        "       ...,\n",
        "       [ 87.5,  87.5,  87.5, ...,  87.5,  87.5,  87.5],\n",
        "       [ 88.5,  88.5,  88.5, ...,  88.5,  88.5,  88.5],\n",
-       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2cb8485e-df9f-4280-99d7-a9b59cd5d5ad' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2cb8485e-df9f-4280-99d7-a9b59cd5d5ad' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-fe46dc75-3e4a-4254-a2bd-ae470d5bc47a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-fe46dc75-3e4a-4254-a2bd-ae470d5bc47a' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "       [ 89.5,  89.5,  89.5, ...,  89.5,  89.5,  89.5]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6d526e5b-0774-49fc-a77f-2a1f833c8e6a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-6d526e5b-0774-49fc-a77f-2a1f833c8e6a' class='xr-section-summary'  title='Expand/collapse section'>Data variables: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-b3b1c7ee-6abd-4855-ba2b-62ed1b67ee0c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-b3b1c7ee-6abd-4855-ba2b-62ed1b67ee0c' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2253,6 +2191,14 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.54 s, sys: 1.53 s, total: 10.1 s\n",
+      "Wall time: 10.5 s\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
        "xESMF Regridder \n",
@@ -2270,6 +2216,7 @@
     }
    ],
    "source": [
+    "%%time\n",
     "ds_in_1deg = ssh_1.drop({'x', 'y'}).to_dataset()\n",
     "\n",
     "regridder_1degACCESSOM2_1deg = xesmf.Regridder(ds_in_1deg, ds_out, 'bilinear', periodic=True,\n",
@@ -2282,6 +2229,14 @@
    "execution_count": 11,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 38.3 s, sys: 3.66 s, total: 41.9 s\n",
+      "Wall time: 42.4 s\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -2300,6 +2255,7 @@
     }
    ],
    "source": [
+    "%%time\n",
     "ds_in_025deg = ssh_025.drop({'x', 'y'})\n",
     "\n",
     "regridder_025degACCESSOM2_1deg = xesmf.Regridder(ds_in_025deg, ds_out, 'bilinear', periodic=True,\n",
@@ -2312,6 +2268,14 @@
    "execution_count": 12,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3min 8s, sys: 14.3 s, total: 3min 22s\n",
+      "Wall time: 3min 24s\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -2330,6 +2294,7 @@
     }
    ],
    "source": [
+    "%%time\n",
     "ds_in_010deg = ssh_010.drop({'x', 'y'})\n",
     "\n",
     "regridder_010degACCESSOM2_1deg = xesmf.Regridder(ds_in_010deg, ds_out, 'bilinear', periodic=True,\n",
@@ -2346,7 +2311,8 @@
     "For large grids (e.g., regridding from 0.10$^\\circ$ grid to a 0.20 $^\\circ$ grid), it might take a while to compute the re-grid weights. But, once you compute them once, you can construct a regridder using the already computed weights from a netCDF file by providing the `reuse_weights=True` argument, e.g.,\n",
     "\n",
     "```python\n",
-    "regridder = xesmf.Regridder(dataset_in, dataset_out, 'bilinear', periodic=True, filename=\"weights_file.nc\", reuse_weights=True)\n",
+    "regridder = xesmf.Regridder(dataset_in, dataset_out, 'bilinear', periodic=True, \n",
+    "                            filename=\"weights_file.nc\", reuse_weights=True)\n",
     "```"
    ]
   },
@@ -2410,7 +2376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -2501,7 +2467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -2532,6 +2498,13 @@
     "ax.coastlines()\n",
     "plt.title('sea surface height difference: 0.10deg - 1deg', fontsize=18);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Remove redundant `dask` requirement from the cookbook, as well as a few other unused options and packages, and some small fixes to text.

`dask` is not required as `xesmf` doesn't parallelise the regridding step, so just makes it seem like those resources are required when they don't make any difference.

Sorry @navidcy I should have checked and suggested these changes at the PR stage.