### PR TITLE
Adjustment to work better for first-time users

### DIFF
--- a/Tutorials/COSIMA_CookBook_Tutorial.ipynb
+++ b/Tutorials/COSIMA_CookBook_Tutorial.ipynb
@@ -905,7 +905,7 @@
    ],
    "source": [
     "vars_025deg = cc.querying.get_variables(session, experiment='025deg_jra55v13_ryf8485_gmredi6')\n",
-    "vars_025deg[vars_025deg['name'].str.lower().str.match('temp')]"
+    "vars_025deg[vars_025deg['name'].str.lower().str.contains('temp')]"
    ]
   },
   {
@@ -10597,9 +10597,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:analysis3-20.04]",
+   "display_name": "Python [conda env:analysis3-22.01]",
    "language": "python",
-   "name": "conda-env-analysis3-20.04-py"
+   "name": "conda-env-analysis3-22.01-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -10611,7 +10611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.10"
   },
   "thumbnail_figure": "assets/cookbook.png"
  },


### PR DESCRIPTION
I've swapped out 'match' for 'contains' when searching for variables (cell 9) because match only looks for a match at the start of variable name, whereas 'contains' can find things like 'pot_rho_2' when you only search for 'rho'

I think I've also incidentally updated the default kernel, which will make it open with the current env:analysis3-unstable and work first try for a while.