### PR TITLE
Fix markdown formatting leading to rendering errors

### DIFF
--- a/DocumentedExamples/Binning_transformation_from_depth_to_potential_density.ipynb
+++ b/DocumentedExamples/Binning_transformation_from_depth_to_potential_density.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Example of a coordinate transformation from z levels to density levels\n",
     "\n",
-    "### Rebinning `ty_trans` to `ty_trans_rho` density levels\n",
+    "## Rebinning `ty_trans` to `ty_trans_rho` density levels\n",
     "\n",
     "This transformation is commonly used for the purpose of decomposing the residual meridional overturning streamfunction into mean and eddy components. The mean is taken to be the time-mean Eulerian transport (time-mean in z coordinates), whilst the residual transport is the time-mean in density coordinates (density surface move in time). The eddy transport is the difference between the residual overturning streamfunction, and the Eulerian transport **transformed from depth to density coordinates** via the time-mean density.\n",
     "\n",
@@ -485,17 +485,9 @@
    "metadata": {},
    "source": [
     "### Step 1: Load density and quantity being binned \n",
-    "(you can choose any other quantity instead of `ty_trans`, e.g. `dzt`. Interpolate density to whatever grid that variable is on)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "737f0c83-72ae-4f83-a83c-9ca88c89823a",
-   "metadata": {},
-   "source": [
-    "#### We will load one year of monthly `ty_trans`, `ty_trans_rho` and `pot_rho_2`\n",
+    "(you can choose any other quantity instead of `ty_trans`, e.g. `dzt`. Interpolate density to whatever grid that variable is on)\n",
     "\n",
-    "Then take weighted time average"
+    "We will load one year of monthly `ty_trans`, `ty_trans_rho` and `pot_rho_2`, then take the weighted time average"
    ]
   },
   {
@@ -607,13 +599,13 @@
    "id": "71635773-a64f-4803-b842-4184be71d4e3",
    "metadata": {},
    "source": [
-    "# Method 1: `xhistogram`\n",
+    "## Method 1: `xhistogram`\n",
     "\n",
     "We use xhistogram, described in https://xhistogram.readthedocs.io/en/latest/. It is a xarray aware method for computing histograms.\n",
     "\n",
     "Computation in xhistogram occurs via the same method as in MOM5 online binning. It is thus most appropriate for an comparisons between offline and online binned quantities.\n",
     "\n",
-    "#### First, we define the edges of the target bins:\n",
+    "### First, we define the edges of the target bins\n",
     "Output will be an array with coordinate density the linear centre of these bins. If we choose `potrho_edges`, the end result will have coordinates potrho, which is the same as online binned `ty_trans_rho`."
    ]
   },
@@ -633,7 +625,7 @@
    "id": "9b43345e-4748-45a7-afbe-3a24f3ad031c",
    "metadata": {},
    "source": [
-    "#### Now apply the histogram over the vertical dimension `st_ocean` inside the target bins. \n",
+    "### Now apply the histogram over the vertical dimension `st_ocean` inside the target bins. \n",
     "We include the variable we want to bin in `weights`. This quantity should be extensive, since grid cells vary in sizes, which is true because `ty_trans` is multiplied by the cell size in x and z directions."
    ]
   },
@@ -681,7 +673,7 @@
    "id": "b2d3e7bd-246a-4c25-a724-8300ff0bbdd9",
    "metadata": {},
    "source": [
-    "#### Now define meridional overturning streamfunctions as a cumulative sum of transport from the bottom of the ocean."
+    "### Now define meridional overturning streamfunctions as a cumulative sum of transport from the bottom of the ocean."
    ]
   },
   {
@@ -713,7 +705,7 @@
    "id": "4bbe9e23-c487-4769-a6d1-14f2b3096e75",
    "metadata": {},
    "source": [
-    "#### Plot streamfunctions of the residual, mean (what we just computed) and eddy (the difference) streamfunctions"
+    "### Plot streamfunctions of the residual, mean (what we just computed) and eddy (the difference) streamfunctions"
    ]
   },
   {
@@ -772,7 +764,7 @@
    "id": "eaaafc08-1df8-4e26-9663-624b5fb8cf65",
    "metadata": {},
    "source": [
-    "# Method 2: `xgcm`\n",
+    "## Method 2: `xgcm`\n",
     "\n",
     "Use `xgcm` conservative binning, described in the tutorial available in `xgcm` documentation: https://xgcm.readthedocs.io/en/stable/transform.html\n",
     "\n",
@@ -784,7 +776,7 @@
    "id": "9e46418e-89b7-449f-bab7-1f259239a55d",
    "metadata": {},
    "source": [
-    "#### Load vertical grid bin centres and edges"
+    "### Load vertical grid bin centres and edges"
    ]
   },
   {
@@ -814,7 +806,7 @@
    "id": "58336fe8-d59d-4489-903a-af25ad35024a",
    "metadata": {},
    "source": [
-    "#### define edge of target density bins"
+    "### Define edge of target density bins"
    ]
   },
   {
@@ -832,7 +824,7 @@
    "id": "93d9620f-60be-482a-932a-ebaf72524cce",
    "metadata": {},
    "source": [
-    "### calculate vertical regridding into density coordinates"
+    "### Calculate vertical regridding into density coordinates"
    ]
   },
   {
@@ -900,7 +892,7 @@
    "id": "10e2fd59-083b-417b-af83-812d202ce0da",
    "metadata": {},
    "source": [
-    "#### Now account for partial cell at bottom\n",
+    "### Now account for partial cell at bottom\n",
     "We do this by finding what is missing from the vertical integral (residual). This is what was in the partial cell. We then add that residual into the densest cell that currently exists in the transformed data. This is only an approximation, because the density of the partial cell may be denser than that of the cell above it. However, this correction means the vertical integral is preserved under the transformation."
    ]
   },
@@ -930,7 +922,7 @@
    "id": "115208ff-07d1-45f4-bcfb-6e7a0290de7a",
    "metadata": {},
    "source": [
-    "#### Find bottom density of `ty_trans_transformed_cons`"
+    "### Find bottom density of `ty_trans_transformed_cons`"
    ]
   },
   {
@@ -961,7 +953,7 @@
    "id": "1096b59c-b87e-47cb-a291-6eb479020d5d",
    "metadata": {},
    "source": [
-    "#### Add residual to this bottom density in array"
+    "### Add residual to this bottom density in array"
    ]
   },
   {
@@ -1022,7 +1014,7 @@
    "id": "75c9d270-47d1-45c1-8796-32944e6b2fb3",
    "metadata": {},
    "source": [
-    "#### Plot streamfunction of result"
+    "### Plot streamfunction of result"
    ]
   },
   {
@@ -1093,7 +1085,7 @@
     "tags": []
    },
    "source": [
-    "# Method 3: Bin `ty_trans` (mean Eulerian overturning) into density bins\n",
+    "## Method 3: Bin `ty_trans` (mean Eulerian overturning) into density bins\n",
     "\n",
     "This uses the method by Lee et al. (2007) and which is is described as follows. Firstly, cells in the model output with a density $\\rho$ between two prescribed densities ($\\rho_\\text{heavy} >\\rho> \\rho_\\text{light}$) are selected. Each cell is assigned a proximity to the lighter density $\\rho_\\text{light}$, which is the 'bin fraction' $$f_b = \\frac{\\rho_\\text{heavy}-\\rho}{\\rho_\\text{heavy}-\\rho_\\text{light}}.$$\n",
     "\n",
@@ -1108,7 +1100,7 @@
    "id": "063607a5-1bd7-4c8f-8cc1-0d89bf2f02d0",
    "metadata": {},
    "source": [
-    "#### For this method, we need to get rid of NaNs"
+    "### For this method, we need to get rid of NaNs"
    ]
   },
   {
@@ -1127,7 +1119,7 @@
    "id": "1645e9d1-f09f-4e3e-b087-383ec4bfb6a6",
    "metadata": {},
    "source": [
-    "#### Load first to reduce computation time"
+    "### Load first to reduce computation time"
    ]
   },
   {
@@ -1245,7 +1237,7 @@
    "id": "35ddc3b8-5d15-413e-8cb6-d5e8073841f8",
    "metadata": {},
    "source": [
-    "#### Plot streamfunctions"
+    "### Plot streamfunctions"
    ]
   },
   {

--- a/DocumentedExamples/SeaIceSeasonality_DFA.ipynb
+++ b/DocumentedExamples/SeaIceSeasonality_DFA.ipynb
@@ -911,7 +911,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Yearly anomaly calculation"
+    "### Yearly anomaly calculation"
    ]
   },
   {

--- a/DocumentedExamples/Surface_Water_Mass_Transformation.ipynb
+++ b/DocumentedExamples/Surface_Water_Mass_Transformation.ipynb
@@ -19,8 +19,9 @@
     "\n",
     "The surface water-mass transformation framework described here follows [Newsom *et al* (2016)](https://journals.ametsoc.org/doi/full/10.1175/JCLI-D-15-0513.1) and [Abernathey *et al* (2016)](https://www.nature.com/articles/ngeo2749). Surface water-mass transformation may be defined as the volume flux into a given density class ($\\sigma$) from lighter density classes ($\\sigma'<\\sigma$) due to surface buoyancy forcing. Integrated over a region of the ocean surface, this volume flux can be expressed as,\n",
     "\n",
-    "\n",
+    "$$\n",
     "\\begin{equation}\\Omega(\\sigma,t)=\\frac{\\partial}{\\partial\\sigma}\\iint_{\\sigma'<\\sigma}\\Big(\\frac{\\partial\\sigma}{\\partial\\theta}\\theta + \\frac{\\partial\\sigma}{\\partial S}S\\Big)\\,dx\\,dy\\end{equation}\n",
+    "$$\n",
     "\n",
     "where $t$ is time, and the terms in the integrand are the potential temperature ($\\theta$) flux and salinity ($S$) flux components of the surface buoyancy flux. The linearity of this expression means we can extract the relative contributions of heat ($\\Omega_\\text{heat}$) and salinity ($\\Omega_\\text{fw}$) fluxes to surface water-mass transformation, highlighting driving mechanisms."
    ]

--- a/Tutorials/Submitting_analysis_jobs_to_gadi.ipynb
+++ b/Tutorials/Submitting_analysis_jobs_to_gadi.ipynb
@@ -193,7 +193,7 @@
     "```\n",
     "\n",
     "\n",
-    "### A different looping strategy\n",
+    "## A different looping strategy\n",
     "\n",
     "Rather than submitting 10 years at the same time, you could also add a counter in your PBS script so that when it gets to the end of the script it will resubmit but update the environment variable to be say the next year. \n",
     "\n",
@@ -239,7 +239,7 @@
    "id": "86d3d252-4c31-4b74-b66a-6f4a507b6eb5",
    "metadata": {},
    "source": [
-    "### Other links\n",
+    "# Other links\n",
     "\n",
     "The CLEX CMS blog https://climate-cms.org/ and wiki http://climate-cms.wikis.unsw.edu.au/Home are great resources with lots of information!"
    ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'COSIMA Recipes'
-copyright = '2020, COSIMA'
+copyright = '2023, COSIMA'
 author = 'COSIMA'
 
 


### PR DESCRIPTION
The reStructuredText backend we use for rendering the notebooks on the [gallery](https://cosima-recipes.readthedocs.io/en/latest/documented_examples/index.html) is pretty sensitive to the nesting of title levels. There were a few titles which were simply being dropped since they dropped from e.g. level 1 to level 4 (or something like that).

Additionally, there was a rendering error in the SWMT notebook stemming from the LaTeX equation not appearing in a math environment.

Finally, I've just bumped the copyright year to 2023 for the RTD config, which will appear on the gallery site linked above!