### PR TITLE
Jenkins failures

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -17,7 +17,7 @@ export set PYTHONNOUSERSITE=1
 
 module purge
 module use /g/data/hh5/public/modules/
-module load $MODULE
+module load \$MODULE
 
 pytest -v --durations=0
 """
@@ -25,13 +25,13 @@ pytest -v --durations=0
 pipeline {
     agent {label 'mo1833.gadi'}
     parameters {
-      string(name: 'MODULE', defaultValue: 'conda/analysis', description: 'Which hh5 module to use')
+      string(name: 'MODULE', description: 'Which hh5 module to use')
     }
     triggers {
         // Run every Sunday at 3 am
         parameterizedCron('''
-            0 3 * * 0 %MODULE=conda/analysis3
-            0 3 * * 0 %MODULE=conda/analysis3-unstable
+            H 3 * * 0 %MODULE=conda/analysis3
+            H 3 * * 0 %MODULE=conda/analysis3-unstable
         ''')
     }
     environment {
@@ -41,7 +41,7 @@ pipeline {
         stage('Tests') {
             steps {
                 writeFile(file: 'run_tests.pbs', text: PBS_SCRIPT)
-                sh 'qsub -v MODULE=${params.MODULE} run_tests.pbs'
+                sh "qsub -v MODULE=${params.MODULE} run_tests.pbs"
             }
         }
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
         // Run every Sunday at 3 am
         parameterizedCron('''
             H 3 * * 0 %MODULE=conda/analysis3
-            H 3 * * 0 %MODULE=conda/analysis3-unstable
+            H 4 * * 0 %MODULE=conda/analysis3-unstable
         ''')
     }
     environment {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -17,16 +17,22 @@ export set PYTHONNOUSERSITE=1
 
 module purge
 module use /g/data/hh5/public/modules/
-module load conda/analysis3
+module load $MODULE
 
 pytest -v --durations=0
 """
 
 pipeline {
     agent {label 'mo1833.gadi'}
+    parameters {
+      string(name: 'MODULE', defaultValue: 'conda/analysis', description: 'Which hh5 module to use')
+    }
     triggers {
         // Run every Sunday at 3 am
-        cron('0 3 * * 0')
+        parameterizedCron('''
+            0 3 * * 0 %MODULE=conda/analysis3
+            0 3 * * 0 %MODULE=conda/analysis3-unstable
+        ''')
     }
     environment {
         EMAILS = credentials('CCRecipesEmails')
@@ -35,7 +41,7 @@ pipeline {
         stage('Tests') {
             steps {
                 writeFile(file: 'run_tests.pbs', text: PBS_SCRIPT)
-                sh 'qsub run_tests.pbs'
+                sh 'qsub -v MODULE=${params.MODULE} run_tests.pbs'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
    <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3}&subject=conda/analysis3'>
 </a>
 <a href='https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/'>
-   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3-unstable}&subject=conda/analysis3'>
+   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3-unstable}&subject=conda/analysis3-unstable'>
 </a>
 
 # cosima-recipes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
     <img alt="latest docs" src="https://img.shields.io/badge/docs-latest-blue.svg">
 </a>
 <a href='https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/'>
-   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test'>
+   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3}'>
+</a>
+<a href='https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/'>
+   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3-unstable}'>
 </a>
 
 # cosima-recipes

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
     <img alt="latest docs" src="https://img.shields.io/badge/docs-latest-blue.svg">
 </a>
 <a href='https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/'>
-   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3}'>
+   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3}&subject=conda/analysis3'>
 </a>
 <a href='https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/'>
-   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3-unstable}'>
+   <img src='https://accessdev.nci.org.au/jenkins/buildStatus/icon?job=COSIMA%2FCC+Recipes+Test&build=last:${params.MODULE=conda/analysis3-unstable}&subject=conda/analysis3'>
 </a>
 
 # cosima-recipes

--- a/Tutorials/Model_Agnostic_Analysis.ipynb
+++ b/Tutorials/Model_Agnostic_Analysis.ipynb
@@ -2,7 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "# Model Agnostic Analysis"
    ]
@@ -4082,7 +4088,15 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "skip-execution"
+    ]
+   },
    "outputs": [
     {
      "ename": "KeyError",
@@ -4227,7 +4241,15 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "skip-execution"
+    ]
+   },
    "outputs": [
     {
      "ename": "ValueError",
@@ -4936,7 +4958,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.17"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/Tutorials/Using_Explorer_tools.ipynb
+++ b/Tutorials/Using_Explorer_tools.ipynb
@@ -2,7 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "# Exploring the COSIMA Cookbook"
    ]
@@ -1414,7 +1420,15 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "skip-execution"
+    ]
+   },
    "outputs": [
     {
      "ename": "QueryWarning",

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,3 @@
+This folder contains the script used by the accessdev jenkins server to run all the notebooks weekly and confirm they are still in a working state.
+
+For cells in notebooks which are expected to fail, you need to add a 'skip-execution' tag which will cause the cell to be skipped in automated testing. To do this, select the cell and open the Property Inspector (click on the icon with two cogged wheels on the right of JupyterLab) and add a tag with the text 'skip-execution'.

--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -35,10 +35,11 @@ def run_notebook(notebook_filename):
         ("COSIMA_CookBook_Tutorial.ipynb"),
         ("Make_Your_Own_Database.ipynb"),
         ("Making_Maps_with_Cartopy.ipynb"),
-        #("Model_Agnostic_Analysis_converted.ipynb"), # Does not run
+        # ("Model_Agnostic_Analysis.ipynb"), # Notebook is expected to fail, demonstrates expected error case.
+        ("Spatial_selection.ipynb"),
         ("Submitting_analysis_jobs_to_gadi.ipynb"),
         ("Template_For_Notebooks.ipynb"),
-        # ("Using_Explorer_tools.ipynb"), # Does not run
+        # ("Using_Explorer_tools.ipynb"), # Notebook is expected to fail, demonstrates expected error case.
     ])
 def test_Tutorials(notebook_filename):
     run_notebook("Tutorials/" + notebook_filename)
@@ -58,17 +59,15 @@ def test_Tutorials(notebook_filename):
         ("Cross-slope_section.ipynb"),
         #("Decomposing_kinetic_energy_into_mean_and_transient.ipynb"), # Takes a long time (not sure if it runs till the end)
         ("Equatorial_thermal_and_zonal_velocity_structure.ipynb"),
-        #("IcePlottingExample.ipynb"), # Does not run
+        # ("IcePlottingExample.ipynb"), # Does not run
         ("Meridional_heat_transport.ipynb"),
         ("Model_Resolution_Comparison.ipynb"),
         ("Particle_tracking_with_Parcels.ipynb"),
         ("Querying_Scalar_Quantities_and_Annually_Averaged_Timeseries.ipynb"),
         ("Regridding.ipynb"),
         ("RelativeVorticity.ipynb"),
-        #("SeaIceSeasonality_DFA.ipynb"), # Does not run
-        ("Spatial_selection.ipynb"),
+        # ("SeaIceSeasonality_DFA.ipynb"), # Does not run
         ("Surface_Water_Mass_Transformation.ipynb"),
-        #("TemperatureSalinityDiagrams.ipynb"), # Does not run
         ("TemperatureSalinityDiagrams_mom5_mom6.ipynb"),
         ("Transport_Through_Straits.ipynb"),
         ("True_Zonal_Mean.ipynb"),

--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -35,11 +35,11 @@ def run_notebook(notebook_filename):
         ("COSIMA_CookBook_Tutorial.ipynb"),
         ("Make_Your_Own_Database.ipynb"),
         ("Making_Maps_with_Cartopy.ipynb"),
-        # ("Model_Agnostic_Analysis.ipynb"), # Notebook is expected to fail, demonstrates expected error case.
+        ("Model_Agnostic_Analysis.ipynb"), 
         ("Spatial_selection.ipynb"),
         ("Submitting_analysis_jobs_to_gadi.ipynb"),
         ("Template_For_Notebooks.ipynb"),
-        # ("Using_Explorer_tools.ipynb"), # Notebook is expected to fail, demonstrates expected error case.
+        ("Using_Explorer_tools.ipynb"), 
     ])
 def test_Tutorials(notebook_filename):
     run_notebook("Tutorials/" + notebook_filename)


### PR DESCRIPTION
Jenkins PR Text - 12 Oct

A few changes to Jenkins:

- Add second jenkins run to use _conda/analysis3-unstable_ to pick up errors in the next jenkins version. (closes #297)
- Fix other jenkins failures introduced by Spatial Selection notebook being moved
- Tidy jenkins file to run recently fixed tests
- Add 'skip-execution' tag to expected failure cells in Tutorials (closes #296 )

See Jenkins runs:

- [65](https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/65/) - still expected to fail due to incorrect Parcels version in _conda/analysis3_ 
- [66](https://accessdev.nci.org.au/jenkins/job/COSIMA/job/CC%20Recipes%20Test/66/) - uses _conda/analysis3-unstable_

The 'skip-execution' flag was added after the jenkins run but confirmed by an ad-hoc test