### PR TITLE
Typo in test_notebooks.py

### DIFF
--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -67,7 +67,6 @@ def test_Tutorials(notebook_filename):
         ("RelativeVorticity.ipynb"),
         ("SeaIce_Plot_Example.ipynb"),
         #("SeaIceSeasonality_DFA.ipynb"), # Does not run
-        ("Spatial_selection.ipynb"),
         ("Surface_Water_Mass_Transformation.ipynb"),
         ("TemperatureSalinityDiagrams_mom5_mom6.ipynb"),
         ("Transport_Through_Straits.ipynb"),


### PR DESCRIPTION
Apologies - during #294 the test_notebooks file was merged wrongly which causes a jenkins failure.

`Spatial_selection.ipynb` is now in DocumentedExamples