### PR TITLE
Add xp65 to jenkins file

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -3,7 +3,7 @@ PBS_SCRIPT = """
 
 #PBS -N test_cc_recipes
 #PBS -P v45
-#PBS -l storage=gdata/ik11+gdata/cj50+gdata/hh5+gdata/jk72+gdata/ua8
+#PBS -l storage=gdata/ik11+gdata/cj50+gdata/hh5+gdata/jk72+gdata/ua8+gdata/xp65
 #PBS -l walltime=8:00:00
 #PBS -l mem=192GB
 #PBS -l jobfs=10GB


### PR DESCRIPTION
Add xp65 to jenkins file so that [Tutorials/Using Intake Catalog](https://github.com/COSIMA/cosima-recipes/blob/main/Tutorials/Using_Intake_Catalog.ipynb) runs in jenkins