### PR TITLE
Add warning to `Cross-contour_transport.ipynb' about conda versions.

### DIFF
--- a/DocumentedExamples/Cross-contour_transport.ipynb
+++ b/DocumentedExamples/Cross-contour_transport.ipynb
@@ -9,6 +9,8 @@
    "source": [
     "# Example: Cross-contour transport\n",
     "\n",
+    "## WARNING: This notebook currently only works with analysis3-23.04 or earlier!!! See issue #327 for details.\n",
+    "\n",
     "This notebook uses the `cosima_cookbook` to calculate transport across an arbitrary contour. We do this by first creating the contour, such as sea surface height, and extracting the coordinates using `matplotlib`'s `Path` class. We then create some masks to indicate which direction is across the contour at each position along the contour. We then load the transport data and compute the transport, resulting in data with dimensions depth and along contour index. \n",
     "\n",
     "Computation times shown used conda environment `analysis3-22.07` on the large compute size on NCI's ARE.\n",


### PR DESCRIPTION
I'd prefer to leave the cross-contour notebook where it is, but let's add a warning, so no one accidentally uses it with the newer conda environments. Just a temporary fix until we find the time to fix properly.