### PR TITLE
Intake conversion Make_Your_Own_Database

### DIFF
--- a/Tutorials/Make_Your_Own_Database.ipynb
+++ b/Tutorials/Make_Your_Own_Database.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "de50bed0",
    "metadata": {},
    "source": [
     "# Make Your Own Database\n",
@@ -14,17 +15,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "3ff6b686",
    "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format='retina'\n",
     "\n",
-    "import cosima_cookbook as cc"
+    "import pandas as pd\n",
+    "import intake\n",
+    "catalog = intake.cat.access_nri"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8a4951b6",
    "metadata": {},
    "source": [
     "**First, create a database session** using the inbuilt `create_session` function. To do this, you need to specify a path for the database - choose a location where you have write permission (that is, not the example that I have given here):"
@@ -33,6 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "39aa0448",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,6 +48,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bf0fb822",
    "metadata": {},
    "source": [
     "Note that you need to create the database session every time you start up your notebook; you can then update this database however many times you like."
@@ -49,6 +56,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ba3e6441",
    "metadata": {},
    "source": [
     "**Now you are ready to build a database.** First, select which *experiments* you want to include in your database. For these purposes, an *experiment* is a directory containing output from a single simulation. (If you use a higher level directory you won't be able to distinguish between experiments.) \n",
@@ -59,6 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "2134b3fe",
    "metadata": {},
    "outputs": [
     {
@@ -124,6 +133,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6bbc0fed",
    "metadata": {},
    "source": [
     "Some warnings could come up. If they look worrisome then seek for advice. 🙂\n",
@@ -143,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "76822d25",
    "metadata": {},
    "outputs": [
     {
@@ -164,13 +175,18 @@
    "source": [
     "experiment = '025deg_jra55_iaf_omip2_cycle6'\n",
     "variable = 'ke_tot'\n",
-    "dataarray = cc.querying.getvar(experiment, variable, session, ncfile='ocean_scalar.nc')\n",
+    "cat_subset = catalog[experiment]\n",
+    "var_search = cat_subset.search(variable=variable)\n",
+    "darray = var_search.to_dask()\n",
+    "darray = darray[variable]\n",
+    "dataarray = darray\n",
     "annual_average = dataarray.resample(time='A').mean(dim='time')\n",
     "annual_average.plot();"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "49185079",
    "metadata": {},
    "source": [
     "To find more about the in-built functions used above, you can use the `help` function. For example:"
@@ -179,6 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "0a24444a",
    "metadata": {},
    "outputs": [
     {
@@ -202,6 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "e15c2059",
    "metadata": {},
    "outputs": [
     {
@@ -252,6 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d1e26f04",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -278,5 +297,5 @@
   "thumbnail_figure": "assets/database.png"
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Following the discussion in issue #313, we propose converting the recipes to use Intake, given that the Cookbook is no longer supported and the ACCESS-NRI Intake catalog is now available.

A few months ago, @max-anu began working on this transition. This pull request contains the changes @max-anu made to the notebook specified in the title.
