### PR TITLE
Intake conversion Using_Explorer_tools

### DIFF
--- a/Tutorials/Using_Explorer_tools.ipynb
+++ b/Tutorials/Using_Explorer_tools.ipynb
@@ -2,19 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
+   "id": "0ec54476",
+   "metadata": {},
    "source": [
     "# Exploring the COSIMA Cookbook"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ddda9bdd",
    "metadata": {},
    "source": [
     "## Statement of problem\n",
@@ -25,6 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "96c89b0b",
    "metadata": {},
    "outputs": [
     {
@@ -43,6 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "fcd391ce",
    "metadata": {},
    "outputs": [
     {
@@ -89,6 +87,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "018c3df7",
    "metadata": {},
    "source": [
     "All the data is contained in netCDF files, of which there are many. At the time of writing this, 48118 netCDF files in the above directories."
@@ -96,6 +95,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5af49375",
    "metadata": {},
    "source": [
     "**GOAL**: access data by specifying an experiment and a variable"
@@ -103,6 +103,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "64a6f98f",
    "metadata": {},
    "source": [
     "## COSIMA Cookbook solution"
@@ -110,6 +111,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1a3173f4",
    "metadata": {},
    "source": [
     "In order to achieve the above goal the COSIMA Cookbook provides tools to search directories looking for netCDF data files, read metadata from the files about the data they contain, and then save this data to an SQL database.\n",
@@ -120,24 +122,26 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "c0f67cfc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import cosima_cookbook as cc"
+    "import intake\n",
+    "catalog = intake.cat.access_nri"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "d86ed226",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "session = cc.database.create_session()"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "71f8272c",
    "metadata": {},
    "outputs": [
     {
@@ -797,11 +801,17 @@
     }
    ],
    "source": [
-    "cc.querying.getvar(expt='01deg_jra55v140_iaf', variable='u', session=session, n=1)"
+    "cat_subset = catalog['01deg_jra55v140_iaf']\n",
+    "var_search = cat_subset.search(variable='u')\n",
+    "var_search = var_search.search(path=var_search.df['path'][0])\n",
+    "darray = var_search.to_dask()\n",
+    "darray = darray['u']\n",
+    "darray"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "dc2567ee",
    "metadata": {},
    "source": [
     "The question then becomes, how do I find out what experiment to use, and what variables are available? Currently the API provides `get_experiments` to give a list of experiments and `get_variables` which returns a list of variables for a given experiment"
@@ -810,6 +820,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "8d98da7a",
    "metadata": {},
    "outputs": [
     {
@@ -1089,6 +1100,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "7eb5ad7e",
    "metadata": {},
    "outputs": [
     {
@@ -1316,6 +1328,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c1194c6f",
    "metadata": {},
    "source": [
     "But there are sometimes duplicate variables with different frequency:"
@@ -1324,6 +1337,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "5c27daec",
    "metadata": {},
    "outputs": [
     {
@@ -1412,6 +1426,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b79f44de",
    "metadata": {},
    "source": [
     "If you just try and load this data you will get an error because you will be trying to load data from different files with different temporal frequency"
@@ -1420,15 +1435,8 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": [
-     "skip-execution"
-    ]
-   },
+   "id": "e8708485",
+   "metadata": {},
    "outputs": [
     {
      "ename": "QueryWarning",
@@ -1445,11 +1453,16 @@
     }
    ],
    "source": [
-    "cc.querying.getvar(expt='01deg_jra55v140_iaf', variable='surface_salt', session=session)"
+    "cat_subset = catalog['01deg_jra55v140_iaf']\n",
+    "var_search = cat_subset.search(variable='surface_salt')\n",
+    "darray = var_search.to_dask()\n",
+    "darray = darray['surface_salt']\n",
+    "darray"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "3d39d2da",
    "metadata": {},
    "source": [
     "## Exploring a Cookbook Database"
@@ -1457,6 +1470,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "00f33c28",
    "metadata": {},
    "source": [
     "The COSIMA Cookbook `explore` submodule seeks to solve the issue of how to find relevant experiments and variables within a Cookbook database and simplify the process of loading this data.\n",
@@ -1469,6 +1483,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "8282ca5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1477,6 +1492,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "06b0bd0a",
    "metadata": {},
    "source": [
     "### Database Explorer"
@@ -1484,6 +1500,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "685a5c97",
    "metadata": {},
    "source": [
     "The first component is `DatabaseExplorer`, which is used to find relevant experiments. Re-use an existing `session` or don't specify `session` and it will start with the default database. \n",
@@ -1506,6 +1523,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "b9b6b26a",
    "metadata": {},
    "outputs": [
     {
@@ -1540,6 +1558,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "068fe948",
    "metadata": {},
    "source": [
     "### Experiment Explorer"
@@ -1547,6 +1566,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "43b8ebb5",
    "metadata": {},
    "source": [
     "The `ExperimentExplorer` can be used independently of the `DatabaseExplorer` if you already know the experiment you wish to load. \n",
@@ -1569,6 +1589,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "acdf1fb6",
    "metadata": {},
    "outputs": [
     {
@@ -1594,6 +1615,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "a7bf1b54",
    "metadata": {},
    "outputs": [
     {
@@ -2181,6 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5464357d",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -26831,5 +26854,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Following the discussion in issue #313, we propose converting the recipes to use Intake, given that the Cookbook is no longer supported and the ACCESS-NRI Intake catalog is now available.

A few months ago, @max-anu began working on this transition. This pull request contains the changes @max-anu made to the notebook specified in the title.
