### PR TITLE
Resolve ssh ambiguity in cookbook tutorial

### DIFF
--- a/Tutorials/COSIMA_CookBook_Tutorial.ipynb
+++ b/Tutorials/COSIMA_CookBook_Tutorial.ipynb
@@ -2380,7 +2380,7 @@
    "source": [
     "### 1.4 Exercises\n",
     "OK, this is a tutorial, so now you have to do some work. Your tasks are to:\n",
-    "* Find and load SSH from an experiment (an experiment... perhaps choose a 1° configuration for start)."
+    "* Find and load sea-surface height (ssh) from an experiment (an experiment... perhaps choose a 1° configuration for start)."
    ]
   },
   {


### PR DESCRIPTION
Few people raised an issue that ssh is also the acronym for secure shell and that could create confusion.