### PR TITLE
Urge users towards Intake catalog rather than cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Just raise [an issue](https://github.com/COSIMA/cosima-recipes/issues) explainin
 
 ### [Tutorials](https://cosima-recipes.readthedocs.io/en/latest/tutorials.html)
 
-The notebook `COSIMA_CookBook_Tutorial.ipynb` outlines the basic philosophy of the `cosima-cookbook`. This is the best place to start if you are not familiar with the `cosima-cookbook`. Also included here are some other tutorials, either related to the cookbook (e.g., `Make_Your_Own_Database.ipynb`) or more general (`Making_Maps_with_Cartopy.ipynb`).
+The notebook `ACCESS-NRI_Intake_Catalog.ipynb` outlines the basic philosophy of the Intake catalog. This is the best place to start if you are not familiar with the Intake catalog. Also included here are some other tutorials, either related to the cookbook (e.g., `Make_Your_Own_Database.ipynb`) or more general (`Making_Maps_with_Cartopy.ipynb`).
 
 Don't miss out the <a href="https://nbviewer.jupyter.org/github/COSIMA/cosima-recipes/blob/master/Tutorials/Using_Explorer_tools.ipynb" target="_blank">tutorial</a> about using `cosima-cookbook`'s `explore` submodule to find out about available experiments and variables in a database. (The `explorer` tutorial is better viewed either via nbviewer or by running the jupyter notebook yourself.)
 

--- a/Tutorials/ACCESS-NRI_Intake_Catalog.ipynb
+++ b/Tutorials/ACCESS-NRI_Intake_Catalog.ipynb
@@ -11,7 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This tutorial demonstrates how to use the ACCESS-NRI Intake catalog to load model or other output. The tutorial also showcases key similarities and differences with the deprecated cosima cookbook.\n",
+    "This tutorial demonstrates how to use the ACCESS-NRI Intake catalog to load model or other output. The tutorial also showcases key similarities and differences with the deprecated COSIMA cookbook.\n",
+    "\n",
+    "⚠️ **Membership to project `xp65` is required to access the ACCESS-NRI Intake catalog** ⚠️\n",
     "\n",
     "This is a concise version of the longer [ACCESS-NRI Intake catalog documentation](https://access-nri-intake-catalog.readthedocs.io/) and related [COSIMA training workshop](https://github.com/ACCESS-Hive/cosima-training-workshop-2023/blob/main/Intake.ipynb). Users are encouraged to refer to these for more detail and demonstrations.\n",
     "\n",
@@ -7163,9 +7165,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:analysis3-23.07]",
+   "display_name": "Python [conda env:analysis3-24.04]",
    "language": "python",
-   "name": "conda-env-analysis3-23.07-py"
+   "name": "conda-env-analysis3-24.04-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -7177,7 +7179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/Tutorials/ACCESS-NRI_Intake_Catalog.ipynb
+++ b/Tutorials/ACCESS-NRI_Intake_Catalog.ipynb
@@ -4,16 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Using the ACCESS-NRI Intake catalog as an alternative to the COSIMA Cookbook"
+    "# How to use the ACCESS-NRI Intake catalog to load model output"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates how to use the ACCESS-NRI Intake catalog, and demonstrates key similarities to and differences from the cosima cookbook\n",
+    "This tutorial demonstrates how to use the ACCESS-NRI Intake catalog to load model or other output. The tutorial also showcases key similarities and differences with the deprecated cosima cookbook.\n",
     "\n",
-    "This notebook is concise version of the longer [ACCESS-NRI Intake catalog documentation](https://access-nri-intake-catalog.readthedocs.io/) and related [COSIMA training workshop](https://github.com/ACCESS-Hive/cosima-training-workshop-2023/blob/main/Intake.ipynb). Users are encouraged to refer to these for more detail and demonstrations. At the time of writing (Oct 2023), the ACCESS-NRI Intake Catalog is under testing and feedback from users is requested.\n",
+    "This is a concise version of the longer [ACCESS-NRI Intake catalog documentation](https://access-nri-intake-catalog.readthedocs.io/) and related [COSIMA training workshop](https://github.com/ACCESS-Hive/cosima-training-workshop-2023/blob/main/Intake.ipynb). Users are encouraged to refer to these for more detail and demonstrations.\n",
     "\n",
     "Requirements: The `conda/analysis3` (tested on `analysis3-23.07`) module from `/g/data/hh5/public/modules`. "
    ]
@@ -26,7 +26,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "editable": true,
@@ -3972,7 +3971,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "editable": true,

--- a/Tutorials/COSIMA_CookBook_Tutorial.ipynb
+++ b/Tutorials/COSIMA_CookBook_Tutorial.ipynb
@@ -6,6 +6,9 @@
    "source": [
     "# How to use the COSIMA Cookbook\n",
     "\n",
+    "## <span style=\"color:red\">⚠️🚨WARNING🚨⚠️</span>\n",
+    "### <span style=\"color:red\"> **`cosima-cookbook` is deprecated and no longer being developed. Use the [ACCESS-NRI Intake catalog](https://cosima-recipes.readthedocs.io/en/latest/Tutorials/ACCESS-NRI_Intake_Catalog.html) instead.**</span>\n",
+    "\n",
     "This notebook is designed to help new users get to grips with the COSIMA Cookbook.\n",
     "\n",
     "It assumes that:\n",
@@ -3616,7 +3619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "thumbnail_figure": "assets/cookbook.png"
  },


### PR DESCRIPTION
This PR is a first step into making ACCESS-NRI Intake catalog the "default". We'd like new users to start learning that instead of putting their effort in the deprecated COSIMA cookbook.

There are still more places we need to fiddle with the text. E.g. README etc.
This is a start though -- feel free to modify more or just approve and we do more later?