### PR TITLE
Update .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,7 +3,7 @@
    "license":"Apache-2.0",
    "creators":[
       {
-         "affiliation":"The University of Melbourne",
+         "affiliation":"University of Melbourne",
          "name":"Navid C. Constantinou",
          "orcid":"0000-0002-8149-4094",
          "type":"ProjectLeader"


### PR DESCRIPTION
Some UniMelb affiliates had "The University of Melbourne" and others "University of Melbourne". The PR homogenises everything to the latter.