### PR TITLE
Urge new contributors to update the `.zenodo.json` + stronger urge to avoid `cosima_cookbook.getvar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ Hence, users who put together a pull request for a new contribution, should ensu
 
 ## Contents
 
-We are in the process of transitioning these recipes from using [cosima-cookbook](https://github.com/COSIMA/cosima-cookbook) infrastructure to load model output to an [_intake catalogue_](https://cosima-recipes.readthedocs.io/en/latest/Tutorials/ACCESS-NRI_Intake_Catalog.html). That said, you will find recipes that use either method to access model data.
-
-We strongly urge you to transition to _intake catalogue_ and (pretty please 🥺) help us with converting all the recipes to using that!
-
 ### [Tutorials](https://cosima-recipes.readthedocs.io/en/latest/tutorials.html)
 
 The notebook [ACCESS-NRI_Intake_Catalog](https://cosima-recipes.readthedocs.io/en/latest/Tutorials/ACCESS-NRI_Intake_Catalog.html) outlines the basic philosophy of the Intake catalog and how to transition from using the cosima-cookbook to the Intake catalogue. This is the best place to start if you are not familiar with the Intake catalog. 
@@ -63,6 +59,11 @@ If you can find a recipe that suits your purposes, then this is the best place t
 ### ACCESS-OM2-GMD-Paper-Figs
 Jupyter notebooks to reproduce (as far as possible) the figures from the [ACCESS-OM2 model announcement paper (*GMD*, 2020)](https://doi.org/10.5194/gmd-13-401-2020). These notebooks are mostly uncommented, but they should be functional. They are intended to demonstrate methods to undertake the calculations used in the paper.
 
+## Loading model output: use _intake_; avoid **deprecated** `cosima_cookbook`
+
+We are in the process of transitioning recipes from using the **deprecated** [cosima-cookbook](https://github.com/COSIMA/cosima-cookbook) infrastructure to load model output to using an [_intake catalogue_](https://cosima-recipes.readthedocs.io/en/latest/Tutorials/ACCESS-NRI_Intake_Catalog.html). That said, you will find recipes that use either method to access model data.
+
+We strongly urge you to transition to _intake catalogue_ and (pretty please 🥺) help us with converting all the recipes to using that!
 
 ## Conditions of use for ACCESS-OM2 output
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To make a contribution follow the steps laid out in the [beginner's guide on how
 https://cosima-recipes.readthedocs.io/en/latest/contributing.html). If they sound intimidating then don't worry!
 Just raise [an issue](https://github.com/COSIMA/cosima-recipes/issues) explaining briefly what the contribution you want to make is and we'll help out with the process!
 
-Contributors to the COSIMA Cookbook are added to the **citable DOI** entry associated with the repository. Hence, users who put together a pull request for a new contribution, should ensure that the pull request also modifies the `.zenodo.json` file to include their affiliation details.
+Contributors to the COSIMA Cookbook are added to the [**citable DOI**](https://github.com/COSIMA/cosima-recipes?tab=readme-ov-file#citation) entry associated with the repository. Hence, users who put together a pull request for a new contribution, should ensure that the pull request also modifies the `.zenodo.json` file to include their affiliation details.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ To make a contribution follow the steps laid out in the [beginner's guide on how
 https://cosima-recipes.readthedocs.io/en/latest/contributing.html). If they sound intimidating then don't worry!
 Just raise [an issue](https://github.com/COSIMA/cosima-recipes/issues) explaining briefly what the contribution you want to make is and we'll help out with the process!
 
-Contributors to the COSIMA Cookbook are added to the [**citable DOI**](https://github.com/COSIMA/cosima-recipes?tab=readme-ov-file#citation) entry associated with the repository. Hence, users who put together a pull request for a new contribution, should ensure that the pull request also modifies the `.zenodo.json` file to include their affiliation details.
+Contributors to the COSIMA Cookbook are added to the [**citable DOI**](https://github.com/COSIMA/cosima-recipes?tab=readme-ov-file#citation) entry associated with the repository.
+Hence, users who put together a pull request for a new contribution, should ensure that the pull request also modifies the `.zenodo.json` file to include their affiliation details.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To make a contribution follow the steps laid out in the [beginner's guide on how
 https://cosima-recipes.readthedocs.io/en/latest/contributing.html). If they sound intimidating then don't worry!
 Just raise [an issue](https://github.com/COSIMA/cosima-recipes/issues) explaining briefly what the contribution you want to make is and we'll help out with the process!
 
-To acknowledge contributions, contributors to the COSIMA Cookbook are added to the **citable DOI** entry associated with the repository. Hence, users who put together a pull request for a new contribution (starting with an issue -- as above), should ensure that the pull request also modifies the .zenodo.json file to include their affiliation details.
+Contributors to the COSIMA Cookbook are added to the **citable DOI** entry associated with the repository. Hence, users who put together a pull request for a new contribution, should ensure that the pull request also modifies the `.zenodo.json` file to include their affiliation details.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To make a contribution follow the steps laid out in the [beginner's guide on how
 https://cosima-recipes.readthedocs.io/en/latest/contributing.html). If they sound intimidating then don't worry!
 Just raise [an issue](https://github.com/COSIMA/cosima-recipes/issues) explaining briefly what the contribution you want to make is and we'll help out with the process!
 
+To acknowledge contributions, contributors to the COSIMA Cookbook are added to the **citable DOI** entry associated with the repository. Hence, users who put together a pull request for a new contribution (starting with an issue -- as above), should ensure that the pull request also modifies the .zenodo.json file to include their affiliation details.
+
 ## Contents
 
 We are in the process of transitioning these recipes from using [cosima-cookbook](https://github.com/COSIMA/cosima-cookbook) infrastructure to load model output to an [_intake catalogue_](https://cosima-recipes.readthedocs.io/en/latest/Tutorials/ACCESS-NRI_Intake_Catalog.html). That said, you will find recipes that use either method to access model data.


### PR DESCRIPTION
Following https://github.com/COSIMA/cosima-recipes/issues/472, small change to contributing section such that authors know they can also add themselves to .json file for zenodo.

Would be good to also update [1](https://github.com/COSIMA/cosima-recipes/wiki/1.-Working-on-a-recipe) and [2](https://cosima-recipes.readthedocs.io/en/latest/contributing.html)