### PR TITLE
Fix sphinx warnings/errors

### DIFF
--- a/Recipes/Along-slope-velocities.ipynb
+++ b/Recipes/Along-slope-velocities.ipynb
@@ -5543,7 +5543,7 @@
    "metadata": {},
    "source": [
     "### Map of along-slope velocity with bathymetry contours. \n",
-    "#### On a Large ARE Instance, this should take ~45 seconds"
+    "**On a Large ARE Instance, this should take ~45 seconds**"
    ]
   },
   {

--- a/Recipes/Geostrophic_Velocities_from_Sea_Level.ipynb
+++ b/Recipes/Geostrophic_Velocities_from_Sea_Level.ipynb
@@ -1678,10 +1678,10 @@
    "id": "d4520ed1-f69e-460e-8a7c-0abb0589387f",
    "metadata": {},
    "source": [
-    "\\begin{eqnarray}\n",
+    "$$\n",
     "    u_{g,s} = -\\frac{g}{f}\\frac{\\partial \\eta}{\\partial y} \\quad \\textrm{and} \\quad\n",
     "    v_{g,s} = \\frac{g}{f}\\frac{\\partial \\eta}{\\partial x}\n",
-    "\\end{eqnarray}"
+    "$$"
    ]
   },
   {

--- a/Recipes/Nearest_Neighbour_Distance.ipynb
+++ b/Recipes/Nearest_Neighbour_Distance.ipynb
@@ -1432,7 +1432,7 @@
    "id": "ce17902e-7eae-4a71-aa8a-94703a1bb4ad",
    "metadata": {},
    "source": [
-    "The sea ice outputs need some processing before we can start our calculations. You can check this [example](IcePlottingExample.ipynb) for a guide on how to load and plot sea ice data.  \n",
+    "The sea ice outputs need some processing before we can start our calculations. You can check this [example](Sea_Ice_Coordinates.ipynb) for a guide on how to load and plot sea ice data.  \n",
     "  \n",
     "We will follow these processing steps:\n",
     "1. Correct time dimension values by subtracting 12 hours,\n",

--- a/Tutorials/Make_Your_Own_Intake_Datastore.ipynb
+++ b/Tutorials/Make_Your_Own_Intake_Datastore.ipynb
@@ -89,8 +89,7 @@
    "id": "bc200ca9-5cba-4413-a550-bd0a4f1b54bd",
    "metadata": {},
    "source": [
-    "# Building the datastore\n",
-    "___"
+    "## Building the datastore"
    ]
   },
   {
@@ -233,7 +232,7 @@
     "tags": []
    },
    "source": [
-    "# Using your datastore"
+    "## Using your datastore"
    ]
   },
   {
@@ -448,7 +447,6 @@
    "metadata": {},
    "source": [
     "# 2. The convenience method: `use_datastore`\n",
-    "___\n",
     "\n",
     "\n",
     "With the `access-nri-intake` v1.1.1 release, it is now possible to build and load datastores, all in a single step.\n",


### PR DESCRIPTION
Lots of inconsistent use of semantic elements (the intake tutorials particularly use headings for emphasis, and overuse section breaks which ends up confusing sphinx), plus a link that wasn't updated and math that Sphinx didn't feel like rendering in an equation environment.