### PR TITLE
URGENT: Eliminate spurious climate-cms links

### DIFF
--- a/Cooking-Lessons-101-Tutorials/Submitting_analysis_jobs_to_gadi.ipynb
+++ b/Cooking-Lessons-101-Tutorials/Submitting_analysis_jobs_to_gadi.ipynb
@@ -70,7 +70,7 @@
     "                 encoding={'EKE': {'shuffle': True, 'zlib': True, 'complevel': 5}}) \n",
     "\n",
     "```\n",
-    "The encoding line helps with compression (see https://climate-cms.org/posts/2018-10-12-create-netcdf.html). You can add extra attributes to the DataSet e.g. `long_name`, `units` etc. too."
+    "The encoding line helps with compression. You can add extra attributes to the DataSet e.g. `long_name`, `units` etc. too."
    ]
   },
   {
@@ -237,8 +237,14 @@
    "source": [
     "## Other links\n",
     "\n",
-    "The CLEX CMS blog https://climate-cms.org/ and wiki http://climate-cms.wikis.unsw.edu.au/Home are great resources with lots of information!"
+    "The CLEX wiki http://climate-cms.wikis.unsw.edu.au/Home is a great resource with lots of information!"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67e8b1c6",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The links to climate-cms.org now point to what appears to be a phishing/compromised site. From #540 :

> Far more concerning is that the link `climate-cms.org` seems to go somewhere sketchy, that link should be nuked as a priority.
> 
> (For further info, I got redirected to a site that asked for a 'Not a robot' tick, and then told me to click 'Allow' to confirm I wasn't a robot. Bailed off the site before whatever 'Allow' dialog was coming appeared.)