### PR TITLE
Improvements to `Geostrophic_Velocities_from_Sea_Level.ipynb`

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -253,6 +253,12 @@
          "name": "Li, Minghang",
          "orcid": "0000-0002-6167-9999",
          "type":"ProjectMember"
+      },
+      {
+         "affiliation": "Australian National University",
+         "name": "Ellepola, Anupiya",
+         "orcid": "0009-0002-8898-0068",
+         "type":"ProjectMember"
       }
    ],
    "keywords": [


### PR DESCRIPTION
Closes #582 

Aside from the instructions, loading variables with intake was improved, and the calculation of geostrophic velocities simplified (no need for ufuncs for `gsw`).